### PR TITLE
Implement Auth service and MVVM login flow

### DIFF
--- a/IOS/Features/Auth/AuthService.swift
+++ b/IOS/Features/Auth/AuthService.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct AuthData: Codable {
+    let accessToken: String
+    let refreshToken: String
+}
+
+final class AuthService {
+    private let baseURL = URL(string: "https://example.com/api")!
+    private let session: URLSession
+    private let authStorageKey = "authData"
+    
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+    
+    // MARK: - Networking
+    func sendVerificationCode(to phone: String) async throws {
+        let url = baseURL.appendingPathComponent("auth/send-code")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["phone": phone])
+        _ = try await session.data(for: request)
+    }
+    
+    func verifyCode(phone: String, code: String) async throws -> AuthData {
+        let url = baseURL.appendingPathComponent("auth/verify-code")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["phone": phone, "code": code])
+        let (data, _) = try await session.data(for: request)
+        return try JSONDecoder().decode(AuthData.self, from: data)
+    }
+    
+    func updateUser(name: String, email: String) async throws {
+        let url = baseURL.appendingPathComponent("user")
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["name": name, "email": email])
+        _ = try await session.data(for: request)
+    }
+    
+    func login(email: String, password: String) async throws -> AuthData {
+        let url = baseURL.appendingPathComponent("auth/login")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["email": email, "password": password])
+        let (data, _) = try await session.data(for: request)
+        return try JSONDecoder().decode(AuthData.self, from: data)
+    }
+    
+    func checkPassword(_ password: String) async throws -> Bool {
+        let url = baseURL.appendingPathComponent("auth/check-password")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["password": password])
+        let (data, _) = try await session.data(for: request)
+        return (try? JSONDecoder().decode([String: Bool].self, from: data)["valid"]) ?? false
+    }
+    
+    // MARK: - Auth Storage
+    func saveAuthData(_ data: AuthData) {
+        if let encoded = try? JSONEncoder().encode(data) {
+            UserDefaults.standard.set(encoded, forKey: authStorageKey)
+        }
+    }
+    
+    func getAuthData() -> AuthData? {
+        guard let data = UserDefaults.standard.data(forKey: authStorageKey) else { return nil }
+        return try? JSONDecoder().decode(AuthData.self, from: data)
+    }
+    
+    func logout() {
+        UserDefaults.standard.removeObject(forKey: authStorageKey)
+    }
+}
+

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var isAuthenticated: Bool = false
+    @Published var errorMessage: String?
+    
+    private let service = AuthService()
+    
+    // MARK: - Actions
+    func login() async {
+        do {
+            let data = try await service.login(email: email, password: password)
+            service.saveAuthData(data)
+            isAuthenticated = true
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func sendVerificationCode(to phone: String) async {
+        do {
+            try await service.sendVerificationCode(to: phone)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func verifyCode(phone: String, code: String) async {
+        do {
+            let data = try await service.verifyCode(phone: phone, code: code)
+            service.saveAuthData(data)
+            isAuthenticated = true
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func updateUser(name: String, email: String) async {
+        do {
+            try await service.updateUser(name: name, email: email)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func checkPassword(_ password: String) async -> Bool {
+        do {
+            return try await service.checkPassword(password)
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+    
+    func logout() {
+        service.logout()
+        isAuthenticated = false
+    }
+}
+

--- a/IOS/Features/Auth/LoginView.swift
+++ b/IOS/Features/Auth/LoginView.swift
@@ -1,11 +1,26 @@
 import SwiftUI
 
 struct LoginView: View {
+    @StateObject private var viewModel = AuthViewModel()
+    
     var body: some View {
-        Text("Login")
+        VStack(spacing: 16) {
+            TextField("Email", text: $viewModel.email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $viewModel.password)
+                .textFieldStyle(.roundedBorder)
+            if let message = viewModel.errorMessage {
+                Text(message).foregroundColor(.red)
+            }
+            Button("Login") {
+                Task { await viewModel.login() }
+            }
+        }
+        .padding()
     }
 }
 
 #Preview {
     LoginView()
 }
+


### PR DESCRIPTION
## Summary
- add `AuthService` with verification, login, and token helpers
- wire up `AuthViewModel` using async/await and storage
- update `LoginView` to use view model for basic login

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b77750a548323a75d55fd751a89c4