### PR TITLE
Add business service and view model for iOS

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -1,5 +1,30 @@
 import Foundation
 
-struct APIClient {
-    // Networking placeholder
+/// Simple API client used by feature services to perform network calls.
+final class APIClient {
+    static let shared = APIClient()
+
+    private let baseURL = URL(string: "https://example.com/api")!
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Performs a request and decodes the response into the expected type.
+    func request<T: Decodable>(_ path: String,
+                               method: String = "GET",
+                               body: Data? = nil) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = method
+
+        if let body = body {
+            request.httpBody = body
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let (data, _) = try await session.data(for: request)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
 }
+

--- a/IOS/Features/BusinessService.swift
+++ b/IOS/Features/BusinessService.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Service responsible for fetching business related data from backend.
+final class BusinessService {
+    private let api = APIClient.shared
+    private let base = "business"
+
+    func getAllBusinesses() async throws -> [Business] {
+        let dtos: [BusinessDTO] = try await api.request(base)
+        return dtos.map(BusinessMapper.map)
+    }
+
+    func getBusinessById(_ id: String) async throws -> Business {
+        let dto: BusinessDTO = try await api.request("\(base)/\(id)")
+        return BusinessMapper.map(dto)
+    }
+
+    func searchBusinesses(_ name: String) async throws -> [Business] {
+        let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? name
+        let dtos: [BusinessDTO] = try await api.request("\(base)/search?name=\(encoded)")
+        return dtos.map(BusinessMapper.map)
+    }
+
+    func getBusinessesByOwner(_ ownerId: String) async throws -> [Business] {
+        let dtos: [BusinessDTO] = try await api.request("\(base)/owner/\(ownerId)")
+        return dtos.map(BusinessMapper.map)
+    }
+
+    func getTopRated(limit: Int = 5) async throws -> [Business] {
+        let dtos: [BusinessDTO] = try await api.request("\(base)/top?limit=\(limit)")
+        return dtos.map(BusinessMapper.map)
+    }
+
+    func getByTag(_ tagId: String) async throws -> [Business] {
+        let dtos: [BusinessDTO] = try await api.request("\(base)/tag/\(tagId)")
+        return dtos.map(BusinessMapper.map)
+    }
+
+    func getBusinessReviews(_ businessId: String) async throws -> [Review] {
+        let dtos: [ReviewDTO] = try await api.request("\(base)/reviews/\(businessId)")
+        return dtos.map(ReviewMapper.map)
+    }
+
+    func getBusinessPromotions(_ businessId: String) async throws -> [Promotion] {
+        let dtos: [PromotionDTO] = try await api.request("\(base)/promotions/\(businessId)")
+        return dtos.map(PromotionMapper.map)
+    }
+
+    func newPromotion(_ businessId: String, promotion: PromotionRequest) async throws -> Promotion {
+        let body = try JSONEncoder().encode(promotion)
+        let dto: PromotionDTO = try await api.request("\(base)/promotions/\(businessId)", method: "POST", body: body)
+        return PromotionMapper.map(dto)
+    }
+
+    func updatePromotion(_ businessId: String, promotionId: String, promotion: PromotionRequest) async throws -> Promotion {
+        let body = try JSONEncoder().encode(promotion)
+        let dto: PromotionDTO = try await api.request("\(base)/promotions/\(businessId)/\(promotionId)", method: "PATCH", body: body)
+        return PromotionMapper.map(dto)
+    }
+
+    func deletePromotion(_ businessId: String, promotionId: String) async throws {
+        let _: EmptyResponse = try await api.request("\(base)/promotions/\(businessId)/\(promotionId)", method: "DELETE")
+    }
+
+    func setViewed(_ reviewId: String) async throws {
+        let _: EmptyResponse = try await api.request("\(base)/reviews/\(reviewId)", method: "PATCH")
+    }
+}
+
+struct PromotionRequest: Encodable {
+    let title: String
+    let description: String?
+    let startDate: String?
+    let endDate: String?
+    let amount: Double?
+    let isActive: Bool
+}
+
+private struct EmptyResponse: Decodable {}

--- a/IOS/Features/BusinessViewModel.swift
+++ b/IOS/Features/BusinessViewModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+@MainActor
+final class BusinessViewModel: ObservableObject {
+    @Published var businesses: [Business] = []
+    @Published var selectedBusiness: Business?
+    @Published var promotions: [Promotion] = []
+    @Published var reviews: [Review] = []
+    @Published var errorMessage: String?
+
+    private let service = BusinessService()
+
+    func fetchAll() async {
+        do {
+            businesses = try await service.getAllBusinesses()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fetchBusiness(id: String) async {
+        do {
+            selectedBusiness = try await service.getBusinessById(id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fetchPromotions(businessId: String) async {
+        do {
+            promotions = try await service.getBusinessPromotions(businessId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fetchReviews(businessId: String) async {
+        do {
+            reviews = try await service.getBusinessReviews(businessId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -1,8 +1,20 @@
 import SwiftUI
 
 struct HomeView: View {
+    @StateObject private var viewModel = BusinessViewModel()
+
     var body: some View {
-        Text("Home")
+        NavigationView {
+            List(viewModel.businesses) { business in
+                NavigationLink(destination: RestaurantDetailView(businessId: business.id)) {
+                    Text(business.name)
+                }
+            }
+            .navigationTitle("Home")
+            .task {
+                await viewModel.fetchAll()
+            }
+        }
     }
 }
 

--- a/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
@@ -1,11 +1,48 @@
 import SwiftUI
 
 struct RestaurantDetailView: View {
+    let businessId: String
+    @StateObject private var viewModel = BusinessViewModel()
+
     var body: some View {
-        Text("Restaurant Detail")
+        List {
+            if let business = viewModel.selectedBusiness {
+                Text(business.name)
+                    .font(.title)
+            } else {
+                Text("Loading...")
+            }
+
+            if !viewModel.promotions.isEmpty {
+                Section("Promotions") {
+                    ForEach(viewModel.promotions) { promo in
+                        VStack(alignment: .leading) {
+                            Text(promo.title).bold()
+                            Text(promo.description)
+                        }
+                    }
+                }
+            }
+
+            if !viewModel.reviews.isEmpty {
+                Section("Reviews") {
+                    ForEach(viewModel.reviews) { review in
+                        VStack(alignment: .leading) {
+                            Text(review.reviewerName).bold()
+                            Text(review.comment)
+                        }
+                    }
+                }
+            }
+        }
+        .task {
+            await viewModel.fetchBusiness(id: businessId)
+            await viewModel.fetchPromotions(businessId: businessId)
+            await viewModel.fetchReviews(businessId: businessId)
+        }
     }
 }
 
 #Preview {
-    RestaurantDetailView()
+    RestaurantDetailView(businessId: "1")
 }

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// MARK: - DTOs from backend
+struct BusinessDTO: Decodable {
+    let id: String
+    let name: String
+    let description: String?
+    let priceRange: String?
+    let avgRating: Double
+    let promotions: [PromotionDTO]
+}
+
+struct PromotionDTO: Decodable {
+    let id: String
+    let title: String
+    let description: String?
+    let startDate: String?
+    let endDate: String?
+    let amount: Double?
+    let active: Bool
+    let createdAt: String?
+}
+
+struct ReviewDTO: Decodable {
+    let id: String
+    let reviewerName: String?
+    let rating: Double
+    let comment: String?
+}
+
+// MARK: - Domain models
+struct Business: Identifiable {
+    let id: String
+    let name: String
+    let description: String
+    let priceRange: String
+    let rating: Double
+    let promotions: [Promotion]
+}
+
+struct Promotion: Identifiable {
+    let id: String
+    let title: String
+    let description: String
+    let startDate: String?
+    let endDate: String?
+    let amount: Double?
+    let isActive: Bool
+    let createdAt: String?
+}
+
+struct Review: Identifiable {
+    let id: String
+    let reviewerName: String
+    let rating: Double
+    let comment: String
+}
+
+// MARK: - Mappers
+enum BusinessMapper {
+    static func map(_ dto: BusinessDTO) -> Business {
+        Business(
+            id: dto.id,
+            name: dto.name,
+            description: dto.description ?? "",
+            priceRange: dto.priceRange ?? "",
+            rating: dto.avgRating,
+            promotions: dto.promotions.map(PromotionMapper.map)
+        )
+    }
+}
+
+enum PromotionMapper {
+    static func map(_ dto: PromotionDTO) -> Promotion {
+        Promotion(
+            id: dto.id,
+            title: dto.title,
+            description: dto.description ?? "",
+            startDate: dto.startDate,
+            endDate: dto.endDate,
+            amount: dto.amount,
+            isActive: dto.active,
+            createdAt: dto.createdAt
+        )
+    }
+}
+
+enum ReviewMapper {
+    static func map(_ dto: ReviewDTO) -> Review {
+        Review(
+            id: dto.id,
+            reviewerName: dto.reviewerName ?? "",
+            rating: dto.rating,
+            comment: dto.comment ?? ""
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Implement networked APIClient for reusable requests
- Add Business models, mappers, and comprehensive BusinessService
- Introduce BusinessViewModel and integrate with Home and Restaurant Detail views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b7a62afec83238a4707b4ef781d9d