### PR TITLE
Add Swift Package manifest and test target

### DIFF
--- a/IOS/IOSTests/IOSTests.swift
+++ b/IOS/IOSTests/IOSTests.swift
@@ -5,13 +5,13 @@
 //  Created by Hamza Tüfekçi on 12.08.2025.
 //
 
-import Testing
+import XCTest
 @testable import IOS
 
-struct IOSTests {
+final class IOSTests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testExample() {
+        // Placeholder test
     }
 
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "projectalphaIOS",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(
+            name: "IOS",
+            targets: ["IOS"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "IOS",
+            path: "IOS",
+            exclude: [
+                "IOS.xcodeproj",
+                "IOSUITests",
+                "IOSTests",
+                "Assets.xcassets"
+            ]
+        ),
+        .testTarget(
+            name: "IOSTests",
+            dependencies: ["IOS"],
+            path: "IOS/IOSTests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- configure Swift Package manifest for iOS app and test target
- convert existing tests to XCTest

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689b8f30001c832396f149bf61997c96