### PR TITLE
Validate HTTPS scheme for API requests

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum APIClientError: Error {
+    case insecureURL
+}
+
 /// Simple API client used by feature services to perform network calls.
 final class APIClient {
     static let shared = APIClient()
@@ -15,7 +19,12 @@ final class APIClient {
     func request<T: Decodable>(_ path: String,
                                method: String = "GET",
                                body: Data? = nil) async throws -> T {
-        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        let url = baseURL.appendingPathComponent(path)
+        guard url.scheme?.lowercased() == "https" else {
+            throw APIClientError.insecureURL
+        }
+
+        var request = URLRequest(url: url)
         request.httpMethod = method
 
         if let body = body {


### PR DESCRIPTION
## Summary
- add APIClientError and ensure requests only use https URLs
- confirmed service base URLs use https

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b7e8b9eec8323b2c4cf139c418f7c