### PR TITLE
Add APIClient tests and configurable base URL

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -7,11 +7,12 @@ enum APIClientError: Error {
 /// Simple API client used by feature services to perform network calls.
 final class APIClient {
     static let shared = APIClient()
-
-    private let baseURL = URL(string: "https://example.com/api")!
+    private let baseURL: URL
     private let session: URLSession
 
-    init(session: URLSession = .shared) {
+    init(baseURL: URL = URL(string: "https://example.com/api")!,
+         session: URLSession = .shared) {
+        self.baseURL = baseURL
         self.session = session
     }
 

--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import IOS
+
+private struct EmptyResponse: Decodable {}
+
+final class APIClientTests: XCTestCase {
+    func testRequestToInsecureURLThrows() async {
+        let client = APIClient(baseURL: URL(string: "http://example.com/api")!)
+        await XCTAssertThrowsError(try await client.request("test") as EmptyResponse) { error in
+            XCTAssertEqual(error as? APIClientError, .insecureURL)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Make `APIClient` configurable with a custom base URL for testing
- Add `APIClientTests` verifying requests to HTTP URLs throw an `insecureURL` error

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689b912b633883239c8824c8c770afec