### PR TITLE
Enforce HTTPS-only network transport on iOS

### DIFF
--- a/IOS/Info.plist
+++ b/IOS/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+    </dict>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Project Alpha iOS
+
+## Testing Environment
+
+### Swift Package
+- Requires macOS and Xcode with SwiftUI.
+- Run `swift test` from the project root on a Mac.
+- Running on Linux fails because the SwiftUI module is unavailable.
+
+### Node Scripts
+- Requires Node.js 18+ and npm.
+- No test script is defined; running `npm test` results in an error.
+- Add a testing framework and `test` script in `package.json` to enable JavaScript tests.


### PR DESCRIPTION
## Summary
- Add iOS `Info.plist` with `NSAppTransportSecurity` and disable `NSAllowsArbitraryLoads`
- Document testing environment requirements for Swift and Node scripts

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b98dfbaf48323bed72f836238c1c8