### PR TITLE
Add Supabase client and auth service with DI

### DIFF
--- a/IOS/Core/SupabaseClient.swift
+++ b/IOS/Core/SupabaseClient.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Supabase
+
+/// Factory and shared access point for the Supabase client.
+enum SupabaseClientFactory {
+    /// Shared Supabase client instance used across the app.
+    static let shared: SupabaseClient = createClient(
+        url: URL(string: "https://your-project.supabase.co")!,
+        anonKey: "public-anon-key"
+    )
+}
+
+/// Creates a new Supabase client with the given URL and anon key.
+func createClient(url: URL, anonKey: String) -> SupabaseClient {
+    SupabaseClient(supabaseURL: url, supabaseKey: anonKey)
+}
+

--- a/IOS/Services/SupabaseAuthService.swift
+++ b/IOS/Services/SupabaseAuthService.swift
@@ -1,0 +1,23 @@
+import Supabase
+
+/// Service handling authentication directly with Supabase.
+final class SupabaseAuthService {
+    private let client: SupabaseClient
+
+    /// Creates a new service with an injectable Supabase client.
+    init(client: SupabaseClient = SupabaseClientFactory.shared) {
+        self.client = client
+    }
+
+    /// Signs in a user with email and password using Supabase Auth.
+    func signIn(email: String, password: String) async throws -> Session? {
+        let response = try await client.auth.signIn(email: email, password: password)
+        return response.session
+    }
+
+    /// Signs out the current user.
+    func signOut() async throws {
+        try await client.auth.signOut()
+    }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,13 @@ let package = Package(
             targets: ["IOS"]
         )
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/supabase-community/supabase-swift.git", from: "1.0.0")
+    ],
     targets: [
         .target(
             name: "IOS",
+            dependencies: ["Supabase"],
             path: "IOS",
             exclude: [
                 "IOS.xcodeproj",


### PR DESCRIPTION
## Summary
- add Supabase Swift SDK via SPM
- create shared Supabase client
- implement Supabase auth service using dependency injection

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9c6d0488323a2a70ccdfb16a34d