### PR TITLE
Expand restaurant details across models and views

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -1,11 +1,45 @@
 import SwiftUI
 
 struct RestaurantRow: View {
+    let restaurant: Restaurant
+
     var body: some View {
-        Text("Restaurant Row")
+        VStack(alignment: .leading, spacing: 4) {
+            Text(restaurant.name)
+                .font(.headline)
+            HStack {
+                Text("⭐️ \(String(format: "%.1f", restaurant.rating))")
+                Text(restaurant.priceRange)
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            if let address = restaurant.address {
+                Text("\(address.street), \(address.city)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !restaurant.tags.isEmpty {
+                Text(restaurant.tags.map { $0.name }.joined(separator: ", "))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 }
 
 #Preview {
-    RestaurantRow()
+    RestaurantRow(
+        restaurant: Business(
+            id: "1",
+            name: "Preview Restaurant",
+            description: "",
+            priceRange: "$$",
+            rating: 4.5,
+            address: Address(id: "a1", street: "Main St", city: "City", district: "District", neighborhood: "Neighborhood"),
+            tags: [Tag(id: "t1", name: "Fast Food")],
+            promotions: []
+        )
+    )
 }

--- a/IOS/Features/BusinessService.swift
+++ b/IOS/Features/BusinessService.swift
@@ -5,33 +5,33 @@ final class BusinessService {
     private let api = APIClient.shared
     private let base = "business"
 
-    func getAllBusinesses() async throws -> [Business] {
+    func getAllBusinesses() async throws -> [Restaurant] {
         let dtos: [BusinessDTO] = try await api.request(base)
         return dtos.map(BusinessMapper.map)
     }
 
-    func getBusinessById(_ id: String) async throws -> Business {
+    func getBusinessById(_ id: String) async throws -> Restaurant {
         let dto: BusinessDTO = try await api.request("\(base)/\(id)")
         return BusinessMapper.map(dto)
     }
 
-    func searchBusinesses(_ name: String) async throws -> [Business] {
+    func searchBusinesses(_ name: String) async throws -> [Restaurant] {
         let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? name
         let dtos: [BusinessDTO] = try await api.request("\(base)/search?name=\(encoded)")
         return dtos.map(BusinessMapper.map)
     }
 
-    func getBusinessesByOwner(_ ownerId: String) async throws -> [Business] {
+    func getBusinessesByOwner(_ ownerId: String) async throws -> [Restaurant] {
         let dtos: [BusinessDTO] = try await api.request("\(base)/owner/\(ownerId)")
         return dtos.map(BusinessMapper.map)
     }
 
-    func getTopRated(limit: Int = 5) async throws -> [Business] {
+    func getTopRated(limit: Int = 5) async throws -> [Restaurant] {
         let dtos: [BusinessDTO] = try await api.request("\(base)/top?limit=\(limit)")
         return dtos.map(BusinessMapper.map)
     }
 
-    func getByTag(_ tagId: String) async throws -> [Business] {
+    func getByTag(_ tagId: String) async throws -> [Restaurant] {
         let dtos: [BusinessDTO] = try await api.request("\(base)/tag/\(tagId)")
         return dtos.map(BusinessMapper.map)
     }

--- a/IOS/Features/BusinessViewModel.swift
+++ b/IOS/Features/BusinessViewModel.swift
@@ -2,8 +2,8 @@ import Foundation
 
 @MainActor
 final class BusinessViewModel: ObservableObject {
-    @Published var businesses: [Business] = []
-    @Published var selectedBusiness: Business?
+    @Published var businesses: [Restaurant] = []
+    @Published var selectedBusiness: Restaurant?
     @Published var promotions: [Promotion] = []
     @Published var reviews: [Review] = []
     @Published var errorMessage: String?

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -7,7 +7,7 @@ struct HomeView: View {
         NavigationView {
             List(viewModel.businesses) { business in
                 NavigationLink(destination: RestaurantDetailView(businessId: business.id)) {
-                    Text(business.name)
+                    RestaurantRow(restaurant: business)
                 }
             }
             .navigationTitle("Home")

--- a/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
@@ -7,8 +7,25 @@ struct RestaurantDetailView: View {
     var body: some View {
         List {
             if let business = viewModel.selectedBusiness {
-                Text(business.name)
-                    .font(.title)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(business.name)
+                        .font(.title)
+                    Text(business.description)
+                    HStack {
+                        Text("⭐️ \(String(format: "%.1f", business.rating))")
+                        Text(business.priceRange)
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    if let address = business.address {
+                        Text("Address: \(address.street), \(address.city)")
+                            .font(.subheadline)
+                    }
+                    if !business.tags.isEmpty {
+                        Text("Tags: \(business.tags.map { $0.name }.joined(separator: ", "))")
+                            .font(.subheadline)
+                    }
+                }
             } else {
                 Text("Loading...")
             }

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -7,7 +7,22 @@ struct BusinessDTO: Decodable {
     let description: String?
     let priceRange: String?
     let avgRating: Double
+    let address: AddressDTO?
+    let tags: [TagDTO]
     let promotions: [PromotionDTO]
+}
+
+struct AddressDTO: Decodable {
+    let id: String?
+    let street: String?
+    let city: String?
+    let district: String?
+    let neighborhood: String?
+}
+
+struct TagDTO: Decodable {
+    let id: String
+    let name: String
 }
 
 struct PromotionDTO: Decodable {
@@ -35,6 +50,8 @@ struct Business: Identifiable {
     let description: String
     let priceRange: String
     let rating: Double
+    let address: Address?
+    let tags: [Tag]
     let promotions: [Promotion]
 }
 
@@ -56,6 +73,19 @@ struct Review: Identifiable {
     let comment: String
 }
 
+struct Address: Identifiable {
+    let id: String
+    let street: String
+    let city: String
+    let district: String
+    let neighborhood: String
+}
+
+struct Tag: Identifiable {
+    let id: String
+    let name: String
+}
+
 // MARK: - Mappers
 enum BusinessMapper {
     static func map(_ dto: BusinessDTO) -> Business {
@@ -65,6 +95,8 @@ enum BusinessMapper {
             description: dto.description ?? "",
             priceRange: dto.priceRange ?? "",
             rating: dto.avgRating,
+            address: AddressMapper.map(dto.address),
+            tags: dto.tags.map(TagMapper.map),
             promotions: dto.promotions.map(PromotionMapper.map)
         )
     }
@@ -93,5 +125,24 @@ enum ReviewMapper {
             rating: dto.rating,
             comment: dto.comment ?? ""
         )
+    }
+}
+
+enum AddressMapper {
+    static func map(_ dto: AddressDTO?) -> Address? {
+        guard let dto = dto else { return nil }
+        return Address(
+            id: dto.id ?? "",
+            street: dto.street ?? "",
+            city: dto.city ?? "",
+            district: dto.district ?? "",
+            neighborhood: dto.neighborhood ?? ""
+        )
+    }
+}
+
+enum TagMapper {
+    static func map(_ dto: TagDTO) -> Tag {
+        Tag(id: dto.id, name: dto.name)
     }
 }

--- a/IOS/Models/Restaurant.swift
+++ b/IOS/Models/Restaurant.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct Restaurant: Identifiable {
-    let id = UUID()
-    var name: String = ""
-}
+/// `Restaurant` is currently represented by the `Business` model.
+/// This alias allows views to refer to restaurants while using the
+/// underlying `Business` data structure which includes description,
+/// price range, rating, address, promotions and tags.
+typealias Restaurant = Business


### PR DESCRIPTION
## Summary
- merge Restaurant model with Business and expose description, price range, rating, address and tags
- surface new fields in Home and detail views via a reusable RestaurantRow

## Testing
- `swift test` *(fails: CONNECT tunnel failed for dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689c70d40c4083238248d36436fdbef6