### PR TITLE
refactor: configure API and supabase

### DIFF
--- a/IOS/Configuration.plist
+++ b/IOS/Configuration.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>API_BASE_URL</key>
+    <string>https://example.com/api</string>
+    <key>SUPABASE_URL</key>
+    <string>https://your-project.supabase.co</string>
+    <key>SUPABASE_ANON_KEY</key>
+    <string>public-anon-key</string>
+</dict>
+</plist>

--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -11,7 +11,7 @@ final class APIClient {
     private let session: URLSession
     private var authData: AuthData?
 
-    init(baseURL: URL = URL(string: "https://example.com/api")!,
+    init(baseURL: URL = AppConfiguration.apiBaseURL,
          session: URLSession = .shared) {
         self.baseURL = baseURL
         self.session = session

--- a/IOS/Core/AppConfiguration.swift
+++ b/IOS/Core/AppConfiguration.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum AppConfiguration {
+    private static let info: [String: Any] = {
+        if let envBaseURL = ProcessInfo.processInfo.environment["API_BASE_URL"],
+           let envSupabaseURL = ProcessInfo.processInfo.environment["SUPABASE_URL"],
+           let envSupabaseKey = ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"] {
+            return [
+                "API_BASE_URL": envBaseURL,
+                "SUPABASE_URL": envSupabaseURL,
+                "SUPABASE_ANON_KEY": envSupabaseKey
+            ]
+        }
+        guard let url = Bundle.module.url(forResource: "Configuration", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            return [:]
+        }
+        return dict
+    }()
+
+    static var apiBaseURL: URL {
+        guard let urlString = info["API_BASE_URL"] as? String,
+              let url = URL(string: urlString) else {
+            fatalError("API_BASE_URL not set")
+        }
+        return url
+    }
+
+    static var supabaseURL: URL {
+        guard let urlString = info["SUPABASE_URL"] as? String,
+              let url = URL(string: urlString) else {
+            fatalError("SUPABASE_URL not set")
+        }
+        return url
+    }
+
+    static var supabaseAnonKey: String {
+        guard let key = info["SUPABASE_ANON_KEY"] as? String else {
+            fatalError("SUPABASE_ANON_KEY not set")
+        }
+        return key
+    }
+}

--- a/IOS/Core/SupabaseClient.swift
+++ b/IOS/Core/SupabaseClient.swift
@@ -5,8 +5,8 @@ import Supabase
 enum SupabaseClientFactory {
     /// Shared Supabase client instance used across the app.
     static let shared: SupabaseClient = createClient(
-        url: URL(string: "https://your-project.supabase.co")!,
-        anonKey: "public-anon-key"
+        url: AppConfiguration.supabaseURL,
+        anonKey: AppConfiguration.supabaseAnonKey
     )
 }
 

--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -26,24 +26,3 @@ final class APIClientTests: XCTestCase {
         }
     }
 }
-
-/// Simple URLProtocol to mock network responses in tests.
-private final class MockURLProtocol: URLProtocol {
-    static var requestHandler: ((URLRequest) -> (HTTPURLResponse, Data))?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        let (response, data) = handler(request)
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
-    }
-
-    override func stopLoading() {}
-}

--- a/IOS/IOSTests/AuthServiceTests.swift
+++ b/IOS/IOSTests/AuthServiceTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import IOS
+
+final class AuthServiceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testLoginParsesAuthData() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/auth/login")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data("{\"accessToken\":\"abc\",\"refreshToken\":\"def\"}".utf8)
+            return (response, data)
+        }
+        let service = AuthService()
+        let auth = try await service.login(email: "test@example.com", password: "secret")
+        XCTAssertEqual(auth.accessToken, "abc")
+        XCTAssertEqual(auth.refreshToken, "def")
+    }
+}

--- a/IOS/IOSTests/BusinessServiceTests.swift
+++ b/IOS/IOSTests/BusinessServiceTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import IOS
+
+final class BusinessServiceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testGetAllBusinessesReturnsData() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/business")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data("[{\"id\":\"1\",\"name\":\"Test\",\"description\":null,\"priceRange\":null,\"avgRating\":4.5,\"address\":null,\"tags\":[],\"promotions\":[]}]".utf8)
+            return (response, data)
+        }
+        let service = BusinessService()
+        let businesses = try await service.getAllBusinesses()
+        XCTAssertEqual(businesses.count, 1)
+        XCTAssertEqual(businesses.first?.id, "1")
+        XCTAssertEqual(businesses.first?.name, "Test")
+    }
+}

--- a/IOS/IOSTests/MockURLProtocol.swift
+++ b/IOS/IOSTests/MockURLProtocol.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,9 @@ let package = Package(
                 "IOSUITests",
                 "IOSTests",
                 "Assets.xcassets"
+            ],
+            resources: [
+                .process("Configuration.plist")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- load API base URL and Supabase keys from `Configuration.plist`
- update API and Supabase clients to use configuration values
- add mock-based tests for AuthService and BusinessService

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f27910ab083238229b71f8bb4cf42