### PR TITLE
Refactor auth service for email-based flows and role-aware login

### DIFF
--- a/IOS/Core/AuthData.swift
+++ b/IOS/Core/AuthData.swift
@@ -4,9 +4,52 @@ import Foundation
 public struct AuthData: Codable {
     public let accessToken: String
     public let refreshToken: String
-    
-    public init(accessToken: String, refreshToken: String) {
+    public let user: User?
+
+    public init(accessToken: String, refreshToken: String, user: User? = nil) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
+        self.user = user
     }
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case accessTokenCamel = "accessToken"
+        case refreshTokenCamel = "refreshToken"
+        case user
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let token = try? container.decode(String.self, forKey: .accessToken) {
+            accessToken = token
+        } else {
+            accessToken = try container.decode(String.self, forKey: .accessTokenCamel)
+        }
+        if let token = try? container.decode(String.self, forKey: .refreshToken) {
+            refreshToken = token
+        } else {
+            refreshToken = try container.decode(String.self, forKey: .refreshTokenCamel)
+        }
+        user = try container.decodeIfPresent(User.self, forKey: .user)
+    }
+}
+
+public struct User: Codable {
+    public let id: String?
+    public let email: String?
+    public let emailConfirmedAt: String?
+    public let appMetadata: AppMetadata?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case email
+        case emailConfirmedAt = "email_confirmed_at"
+        case appMetadata = "app_metadata"
+    }
+}
+
+public struct AppMetadata: Codable {
+    public let role: String?
 }

--- a/IOS/Features/Auth/AuthService.swift
+++ b/IOS/Features/Auth/AuthService.swift
@@ -6,34 +6,28 @@ final class AuthService {
     private let authStorageKey = "authData"
 
     // MARK: - Networking
-    func sendVerificationCode(to phone: String) async throws {
-        let body = try JSONEncoder().encode(["phone": phone])
-        let _: EmptyResponse = try await api.request("auth/send-code", method: "POST", body: body)
+    func sendVerificationCode(email: String) async throws {
+        let body = try JSONEncoder().encode(["email": email])
+        let _: EmptyResponse = try await api.request("api/auth/send-verification-code", method: "POST", body: body)
     }
 
-    func verifyCode(phone: String, code: String) async throws -> AuthData {
-        let body = try JSONEncoder().encode(["phone": phone, "code": code])
-        let auth: AuthData = try await api.request("auth/verify-code", method: "POST", body: body)
+    func verifyCode(email: String, token: String) async throws -> AuthData {
+        let body = try JSONEncoder().encode(["email": email, "token": token])
+        let auth: AuthData = try await api.request("api/auth/verify-verification-code", method: "POST", body: body)
         api.setAuthData(auth)
         return auth
     }
 
-    func updateUser(name: String, email: String) async throws {
-        let body = try JSONEncoder().encode(["name": name, "email": email])
-        let _: EmptyResponse = try await api.request("user", method: "PUT", body: body)
+    func updateUser(email: String, password: String, role: String) async throws {
+        let body = try JSONEncoder().encode(["email": email, "password": password, "role": role])
+        let _: EmptyResponse = try await api.request("api/auth/update-user", method: "POST", body: body)
     }
 
-    func login(email: String, password: String) async throws -> AuthData {
-        let body = try JSONEncoder().encode(["email": email, "password": password])
-        let auth: AuthData = try await api.request("auth/login", method: "POST", body: body)
+    func login(email: String, password: String, role: String) async throws -> AuthData {
+        let body = try JSONEncoder().encode(["email": email, "password": password, "role": role])
+        let auth: AuthData = try await api.request("api/auth/login", method: "POST", body: body)
         api.setAuthData(auth)
         return auth
-    }
-
-    func checkPassword(_ password: String) async throws -> Bool {
-        let body = try JSONEncoder().encode(["password": password])
-        let response: [String: Bool] = try await api.request("auth/check-password", method: "POST", body: body)
-        return response["valid"] ?? false
     }
 
     // MARK: - Auth Storage

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 final class AuthViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
+    @Published var role: String = "user"
     @Published var isAuthenticated: Bool = false
     @Published var errorMessage: String?
     
@@ -12,7 +13,7 @@ final class AuthViewModel: ObservableObject {
     // MARK: - Actions
     func login() async {
         do {
-            let data = try await service.login(email: email, password: password)
+            let data = try await service.login(email: email, password: password, role: role)
             service.saveAuthData(data)
             isAuthenticated = true
             errorMessage = nil
@@ -20,18 +21,18 @@ final class AuthViewModel: ObservableObject {
             errorMessage = error.localizedDescription
         }
     }
-    
-    func sendVerificationCode(to phone: String) async {
+
+    func sendVerificationCode(email: String) async {
         do {
-            try await service.sendVerificationCode(to: phone)
+            try await service.sendVerificationCode(email: email)
         } catch {
             errorMessage = error.localizedDescription
         }
     }
-    
-    func verifyCode(phone: String, code: String) async {
+
+    func verifyCode(email: String, token: String) async {
         do {
-            let data = try await service.verifyCode(phone: phone, code: code)
+            let data = try await service.verifyCode(email: email, token: token)
             service.saveAuthData(data)
             isAuthenticated = true
             errorMessage = nil
@@ -39,21 +40,12 @@ final class AuthViewModel: ObservableObject {
             errorMessage = error.localizedDescription
         }
     }
-    
-    func updateUser(name: String, email: String) async {
+
+    func updateUser(email: String, password: String, role: String) async {
         do {
-            try await service.updateUser(name: name, email: email)
+            try await service.updateUser(email: email, password: password, role: role)
         } catch {
             errorMessage = error.localizedDescription
-        }
-    }
-    
-    func checkPassword(_ password: String) async -> Bool {
-        do {
-            return try await service.checkPassword(password)
-        } catch {
-            errorMessage = error.localizedDescription
-            return false
         }
     }
     

--- a/IOS/IOSTests/AuthServiceTests.swift
+++ b/IOS/IOSTests/AuthServiceTests.swift
@@ -17,12 +17,17 @@ final class AuthServiceTests: XCTestCase {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url?.path, "/api/auth/login")
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            let data = Data("{\"accessToken\":\"abc\",\"refreshToken\":\"def\"}".utf8)
+            let json = "{" +
+                "\"access_token\":\"abc\"," +
+                "\"refresh_token\":\"def\"," +
+                "\"user\":{\"id\":\"1\",\"email\":\"test@example.com\",\"app_metadata\":{\"role\":\"user\"}}}" 
+            let data = Data(json.utf8)
             return (response, data)
         }
         let service = AuthService()
-        let auth = try await service.login(email: "test@example.com", password: "secret")
+        let auth = try await service.login(email: "test@example.com", password: "secret", role: "user")
         XCTAssertEqual(auth.accessToken, "abc")
         XCTAssertEqual(auth.refreshToken, "def")
+        XCTAssertEqual(auth.user?.id, "1")
     }
 }


### PR DESCRIPTION
## Summary
- Switch AuthService to new `/api/auth` email verification endpoints and role-aware login
- Extend AuthData with user information model
- Update AuthViewModel and unit tests to match new signatures

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f3251ee64832398b764b4c6d5f28d