### PR TITLE
Add verification response model and update auth handling

### DIFF
--- a/IOS/Core/AuthData.swift
+++ b/IOS/Core/AuthData.swift
@@ -15,24 +15,7 @@ public struct AuthData: Codable {
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
         case refreshToken = "refresh_token"
-        case accessTokenCamel = "accessToken"
-        case refreshTokenCamel = "refreshToken"
         case user
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let token = try? container.decode(String.self, forKey: .accessToken) {
-            accessToken = token
-        } else {
-            accessToken = try container.decode(String.self, forKey: .accessTokenCamel)
-        }
-        if let token = try? container.decode(String.self, forKey: .refreshToken) {
-            refreshToken = token
-        } else {
-            refreshToken = try container.decode(String.self, forKey: .refreshTokenCamel)
-        }
-        user = try container.decodeIfPresent(User.self, forKey: .user)
     }
 }
 

--- a/IOS/Features/Auth/AuthService.swift
+++ b/IOS/Features/Auth/AuthService.swift
@@ -11,11 +11,10 @@ final class AuthService {
         let _: EmptyResponse = try await api.request("api/auth/send-verification-code", method: "POST", body: body)
     }
 
-    func verifyCode(email: String, token: String) async throws -> AuthData {
+    func verifyCode(email: String, token: String) async throws -> VerificationResponse {
         let body = try JSONEncoder().encode(["email": email, "token": token])
-        let auth: AuthData = try await api.request("api/auth/verify-verification-code", method: "POST", body: body)
-        api.setAuthData(auth)
-        return auth
+        let response: VerificationResponse = try await api.request("api/auth/verify-verification-code", method: "POST", body: body)
+        return response
     }
 
     func updateUser(email: String, password: String, role: String) async throws {

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -32,9 +32,7 @@ final class AuthViewModel: ObservableObject {
 
     func verifyCode(email: String, token: String) async {
         do {
-            let data = try await service.verifyCode(email: email, token: token)
-            service.saveAuthData(data)
-            isAuthenticated = true
+            _ = try await service.verifyCode(email: email, token: token)
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription

--- a/IOS/Features/Auth/VerificationResponse.swift
+++ b/IOS/Features/Auth/VerificationResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Response returned after verifying a code.
+struct VerificationResponse: Decodable {
+    let token: String
+    let userId: String
+}

--- a/IOS/IOSTests/AuthServiceTests.swift
+++ b/IOS/IOSTests/AuthServiceTests.swift
@@ -30,4 +30,20 @@ final class AuthServiceTests: XCTestCase {
         XCTAssertEqual(auth.refreshToken, "def")
         XCTAssertEqual(auth.user?.id, "1")
     }
+
+    func testVerifyCodeParsesVerificationResponse() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/auth/verify-verification-code")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let json = "{" +
+                "\"token\":\"abc\"," +
+                "\"userId\":\"1\"}"
+            let data = Data(json.utf8)
+            return (response, data)
+        }
+        let service = AuthService()
+        let verification = try await service.verifyCode(email: "test@example.com", token: "123456")
+        XCTAssertEqual(verification.token, "abc")
+        XCTAssertEqual(verification.userId, "1")
+    }
 }


### PR DESCRIPTION
## Summary
- Map `access_token` and `refresh_token` to Swift properties via `CodingKeys`
- Add `VerificationResponse` for token and user ID from `verifyCode`
- Update `AuthService` and view model to use new verification response and adjust auth flow

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git)*

------
https://chatgpt.com/codex/tasks/task_e_689f339a439c83238d87ea9731507e6b