### PR TITLE
Add surname and phone to user profile with role persistence

### DIFF
--- a/IOS/Features/Profile/ProfileView.swift
+++ b/IOS/Features/Profile/ProfileView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
     @State private var name: String = ""
+    @State private var surname: String = ""
+    @State private var phoneNumber: String = ""
     @State private var email: String = ""
 
     var body: some View {
@@ -10,10 +12,14 @@ struct ProfileView: View {
             if let profile = viewModel.profile {
                 TextField("Name", text: $name)
                     .textFieldStyle(.roundedBorder)
+                TextField("Surname", text: $surname)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Phone Number", text: $phoneNumber)
+                    .textFieldStyle(.roundedBorder)
                 TextField("Email", text: $email)
                     .textFieldStyle(.roundedBorder)
                 Button("Save") {
-                    Task { await viewModel.updateProfile(name: name, email: email) }
+                    Task { await viewModel.updateProfile(name: name, surname: surname, phoneNumber: phoneNumber, email: email) }
                 }
             } else {
                 Text(viewModel.errorMessage ?? "Loading...")
@@ -25,6 +31,8 @@ struct ProfileView: View {
             await viewModel.loadProfile()
             if let profile = viewModel.profile {
                 name = profile.name
+                surname = profile.surname ?? ""
+                phoneNumber = profile.phoneNumber ?? ""
                 email = profile.email ?? ""
             }
         }

--- a/IOS/Features/Profile/ProfileViewModel.swift
+++ b/IOS/Features/Profile/ProfileViewModel.swift
@@ -18,9 +18,9 @@ final class ProfileViewModel: ObservableObject {
         }
     }
 
-    func updateProfile(name: String, email: String?) async {
+    func updateProfile(name: String, surname: String?, phoneNumber: String?, email: String?) async {
         guard let userId = session.getUserId() else { return }
-        let updated = UserProfile(id: userId, name: name, email: email)
+        let updated = UserProfile(id: userId, name: name, email: email, surname: surname, phoneNumber: phoneNumber)
         do {
             profile = try await service.updateUserData(userId: userId, profile: updated)
             errorMessage = nil


### PR DESCRIPTION
## Summary
- capture surname and phone number in UserProfile with backend key mapping
- persist user role and favorites list ID and send DinerUpdateRequest during profile updates
- expose surname and phone number fields in profile view/model

## Testing
- `swift test` *(fails: unable to clone dependency supabase-swift)*

------
https://chatgpt.com/codex/tasks/task_e_689f371a803483238a59cf3eeeb54e3d