### PR TITLE
Use integer promotion amounts

### DIFF
--- a/IOS/Features/BusinessService.swift
+++ b/IOS/Features/BusinessService.swift
@@ -72,7 +72,7 @@ struct PromotionRequest: Encodable {
     let description: String?
     let startDate: String?
     let endDate: String?
-    let amount: Double?
+    let amount: Int?
     let isActive: Bool
 }
 

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -31,7 +31,7 @@ struct PromotionDTO: Decodable {
     let description: String?
     let startDate: String?
     let endDate: String?
-    let amount: Double?
+    let amount: Int?
     let active: Bool
     let createdAt: String?
 }
@@ -61,7 +61,7 @@ struct Promotion: Identifiable {
     let description: String
     let startDate: String?
     let endDate: String?
-    let amount: Double?
+    let amount: Int?
     let isActive: Bool
     let createdAt: String?
 }

--- a/frontend/src/services/businessService.js
+++ b/frontend/src/services/businessService.js
@@ -78,7 +78,7 @@ export const newPromotion = async (businessId, newPromotionData) => {
         description: newPromotionData.description,
         startDate: newPromotionData.startDate,
         endDate: newPromotionData.endDate,
-        amount: newPromotionData.amount,
+        amount: parseInt(newPromotionData.amount, 10),
         isActive: newPromotionData.isActive
     };
 
@@ -91,7 +91,7 @@ export const updatePromotion = async (businessId, promotionId, newPromotionData)
         description: newPromotionData.description,
         startDate: newPromotionData.startDate,
         endDate: newPromotionData.endDate,
-        amount: newPromotionData.amount,
+        amount: parseInt(newPromotionData.amount, 10),
         isActive: newPromotionData.isActive
     };
 


### PR DESCRIPTION
## Summary
- Use `Int?` for promotion request amount
- Decode and map promotion amounts as integers
- Parse promotion amounts to integers before sending to backend

## Testing
- `swift test` *(fails: unable to clone repository `supabase-swift`)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 44 errors, 6 warnings)*
- `npx eslint src/services/businessService.js`


------
https://chatgpt.com/codex/tasks/task_e_689f39dc03288323bf1beb4ccae55a45