### PR TITLE
Save user session after login

### DIFF
--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -7,13 +7,15 @@ final class AuthViewModel: ObservableObject {
     @Published var role: String = "user"
     @Published var isAuthenticated: Bool = false
     @Published var errorMessage: String?
-    
+
     private let service = AuthService()
-    
+    private let session = UserSession.shared
+
     // MARK: - Actions
     func login() async {
         do {
             let data = try await service.login(email: email, password: password, role: role)
+            session.save(userId: data.user?.id, token: data.accessToken)
             service.saveAuthData(data)
             isAuthenticated = true
             errorMessage = nil


### PR DESCRIPTION
## Summary
- Save logged-in user's id and token using `UserSession` in `AuthViewModel`
- Keep `saveAuthData` call to ensure `APIClient` uses the auth token

## Testing
- `swift test` *(fails: unable to clone `supabase-swift` dependency, 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e93d7d48323a3e5dba6343272da