### PR TITLE
Support public lists and dynamic favorites in iOS client

### DIFF
--- a/IOS/Features/Lists/ListsViewModel.swift
+++ b/IOS/Features/Lists/ListsViewModel.swift
@@ -18,10 +18,10 @@ final class ListsViewModel: ObservableObject {
         }
     }
 
-    func createList(name: String) async {
+    func createList(name: String, isPublic: Bool = false) async {
         guard let userId = session.getUserId() else { return }
         do {
-            let newList = try await service.createList(userId: userId, name: name)
+            let newList = try await service.createList(userId: userId, name: name, isPublic: isPublic)
             lists.append(newList)
             errorMessage = nil
         } catch {


### PR DESCRIPTION
## Summary
- Expose `isPublic` and `likeCount` on `UserList` and send `is_public` when creating or updating lists
- Fetch public lists from `/api/users/diner_user/public/lists`
- Use stored favorites list ID for favorite operations

## Testing
- `swift test` *(fails: unable to clone supabase-swift dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b2c52608323873a6f7d74212d56