### PR TITLE
refactor: update business service base path

### DIFF
--- a/IOS/Features/BusinessService.swift
+++ b/IOS/Features/BusinessService.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Service responsible for fetching business related data from backend.
 final class BusinessService {
     private let api = APIClient.shared
-    private let base = "business"
+    private let base = "api/business"
 
     func getAllBusinesses() async throws -> [Restaurant] {
         let dtos: [BusinessDTO] = try await api.request(base)


### PR DESCRIPTION
## Summary
- use new `api/business` base path in `BusinessService`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f4fb08004832391731bfa584c0325