### PR TITLE
Fetch user profile after login

### DIFF
--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -10,6 +10,7 @@ final class AuthViewModel: ObservableObject {
 
     private let service = AuthService()
     private let session = UserSession.shared
+    private let userService = UserService()
 
     // MARK: - Actions
     func login() async {
@@ -17,6 +18,9 @@ final class AuthViewModel: ObservableObject {
             let data = try await service.login(email: email, password: password, role: role)
             session.save(userId: data.user?.id, token: data.accessToken)
             service.saveAuthData(data)
+            if let id = data.user?.id {
+                try await userService.fetchUserData(userId: id, role: role)
+            }
             isAuthenticated = true
             errorMessage = nil
         } catch {

--- a/IOS/Services/ListService.swift
+++ b/IOS/Services/ListService.swift
@@ -20,7 +20,10 @@ struct UserList: Identifiable, Decodable {
 final class ListService {
     private let api = APIClient.shared
     private let userService = UserService()
-    private let base = "api/users/diner_user"
+    private var base: String {
+        let role = userService.getUserRoleFromStorage() ?? "diner_user"
+        return "api/users/\(role)"
+    }
 
     func addToList(userId: String, listId: String, itemId: String) async throws {
         let path = "\(base)/\(userId)/lists/\(listId)/items/\(itemId)"


### PR DESCRIPTION
## Summary
- Fetch user profile and list info after login and persist role and favorites list id
- Store user role and favorites list id for later list operations
- Use stored role when calling list APIs

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f5d5a1ea88323a46a569c591d47f1