### PR TITLE
Wire ViewModels to services and views

### DIFF
--- a/IOS/Features/Favorites/FavoritesView.swift
+++ b/IOS/Features/Favorites/FavoritesView.swift
@@ -4,8 +4,18 @@ struct FavoritesView: View {
     @StateObject private var viewModel = FavoritesViewModel()
 
     var body: some View {
-        Text("Favorites")
-            .navigationTitle("Favorites")
+        List(viewModel.favorites) { restaurant in
+            Text(restaurant.name)
+        }
+        .navigationTitle("Favorites")
+        .task {
+            await viewModel.loadFavorites()
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 

--- a/IOS/Features/Favorites/FavoritesViewModel.swift
+++ b/IOS/Features/Favorites/FavoritesViewModel.swift
@@ -2,4 +2,21 @@ import Foundation
 
 @MainActor
 final class FavoritesViewModel: ObservableObject {
+    @Published var favorites: [Restaurant] = []
+    @Published var errorMessage: String?
+
+    private let service = ListService()
+    private let userService = UserService()
+    private let session = UserSession.shared
+
+    func loadFavorites() async {
+        guard let userId = session.getUserId(),
+              let favoritesId = userService.getUserFavoritesIdFromStorage() else { return }
+        do {
+            favorites = try await service.getUserListItems(userId: userId, listId: favoritesId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/IOS/Features/InsideDiscover/InsideDiscoverView.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverView.swift
@@ -4,8 +4,18 @@ struct InsideDiscoverView: View {
     @StateObject private var viewModel = InsideDiscoverViewModel()
 
     var body: some View {
-        Text("Inside Discover")
-            .navigationTitle("Discover")
+        List(viewModel.businesses) { business in
+            Text(business.name)
+        }
+        .navigationTitle("Discover")
+        .task {
+            await viewModel.loadTopRated()
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 

--- a/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
@@ -2,4 +2,17 @@ import Foundation
 
 @MainActor
 final class InsideDiscoverViewModel: ObservableObject {
+    @Published var businesses: [Restaurant] = []
+    @Published var errorMessage: String?
+
+    private let service = BusinessService()
+
+    func loadTopRated() async {
+        do {
+            businesses = try await service.getTopRated()
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/IOS/Features/InsideList/InsideListView.swift
+++ b/IOS/Features/InsideList/InsideListView.swift
@@ -1,14 +1,25 @@
 import SwiftUI
 
 struct InsideListView: View {
+    let list: UserList
     @StateObject private var viewModel = InsideListViewModel()
 
     var body: some View {
-        Text("Inside List")
-            .navigationTitle("List")
+        List(viewModel.items) { restaurant in
+            Text(restaurant.name)
+        }
+        .navigationTitle(list.name)
+        .task {
+            await viewModel.loadItems(listId: list.id)
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 
 #Preview {
-    InsideListView()
+    InsideListView(list: .init(id: "1", name: "Sample", isFavorite: false, isPublic: true, likeCount: 0))
 }

--- a/IOS/Features/InsideList/InsideListViewModel.swift
+++ b/IOS/Features/InsideList/InsideListViewModel.swift
@@ -2,4 +2,19 @@ import Foundation
 
 @MainActor
 final class InsideListViewModel: ObservableObject {
+    @Published var items: [Restaurant] = []
+    @Published var errorMessage: String?
+
+    private let service = ListService()
+    private let session = UserSession.shared
+
+    func loadItems(listId: String) async {
+        guard let userId = session.getUserId() else { return }
+        do {
+            items = try await service.getUserListItems(userId: userId, listId: listId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/IOS/Features/MyReviews/MyReviewsView.swift
+++ b/IOS/Features/MyReviews/MyReviewsView.swift
@@ -4,8 +4,23 @@ struct MyReviewsView: View {
     @StateObject private var viewModel = MyReviewsViewModel()
 
     var body: some View {
-        Text("My Reviews")
-            .navigationTitle("My Reviews")
+        List(viewModel.reviews) { review in
+            VStack(alignment: .leading) {
+                Text("Rating: \(review.rating)")
+                if let comment = review.comment {
+                    Text(comment)
+                }
+            }
+        }
+        .navigationTitle("My Reviews")
+        .task {
+            await viewModel.loadReviews()
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 

--- a/IOS/Features/MyReviews/MyReviewsViewModel.swift
+++ b/IOS/Features/MyReviews/MyReviewsViewModel.swift
@@ -2,4 +2,19 @@ import Foundation
 
 @MainActor
 final class MyReviewsViewModel: ObservableObject {
+    @Published var reviews: [UserReview] = []
+    @Published var errorMessage: String?
+
+    private let service = UserService()
+    private let session = UserSession.shared
+
+    func loadReviews() async {
+        guard let userId = session.getUserId() else { return }
+        do {
+            reviews = try await service.getUserReviews(userId: userId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/IOS/Features/RestaurantRegistration/RestaurantRegistrationView.swift
+++ b/IOS/Features/RestaurantRegistration/RestaurantRegistrationView.swift
@@ -4,8 +4,18 @@ struct RestaurantRegistrationView: View {
     @StateObject private var viewModel = RestaurantRegistrationViewModel()
 
     var body: some View {
-        Text("Restaurant Registration")
-            .navigationTitle("Register")
+        List(viewModel.restaurants) { restaurant in
+            Text(restaurant.name)
+        }
+        .navigationTitle("Register")
+        .task {
+            await viewModel.loadOwnedBusinesses()
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 

--- a/IOS/Features/RestaurantRegistration/RestaurantRegistrationViewModel.swift
+++ b/IOS/Features/RestaurantRegistration/RestaurantRegistrationViewModel.swift
@@ -2,4 +2,19 @@ import Foundation
 
 @MainActor
 final class RestaurantRegistrationViewModel: ObservableObject {
+    @Published var restaurants: [Restaurant] = []
+    @Published var errorMessage: String?
+
+    private let service = BusinessService()
+    private let session = UserSession.shared
+
+    func loadOwnedBusinesses() async {
+        guard let ownerId = session.getUserId() else { return }
+        do {
+            restaurants = try await service.getBusinessesByOwner(ownerId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/IOS/Features/UserLists/UserListsView.swift
+++ b/IOS/Features/UserLists/UserListsView.swift
@@ -4,8 +4,18 @@ struct UserListsView: View {
     @StateObject private var viewModel = UserListsViewModel()
 
     var body: some View {
-        Text("User Lists")
-            .navigationTitle("User Lists")
+        List(viewModel.likedLists) { like in
+            Text(like.name ?? "Unnamed")
+        }
+        .navigationTitle("User Lists")
+        .task {
+            await viewModel.loadLikes()
+        }
+        .overlay {
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
     }
 }
 

--- a/IOS/Features/UserLists/UserListsViewModel.swift
+++ b/IOS/Features/UserLists/UserListsViewModel.swift
@@ -2,4 +2,19 @@ import Foundation
 
 @MainActor
 final class UserListsViewModel: ObservableObject {
+    @Published var likedLists: [UserLike] = []
+    @Published var errorMessage: String?
+
+    private let service = UserService()
+    private let session = UserSession.shared
+
+    func loadLikes() async {
+        guard let userId = session.getUserId() else { return }
+        do {
+            likedLists = try await service.getUserLikes(userId: userId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Implement Favorites, Discover, List, MyReviews, RestaurantRegistration, and UserLists view models with service injections, published state, async loaders, and error handling
- Connect corresponding SwiftUI views to their view models to load data and display lists

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f5fd66fb88323b3d0ceaaf2dd278d