### PR TITLE
Link authentication state with AppViewModel

### DIFF
--- a/IOS/FeastFineiOSApp.swift
+++ b/IOS/FeastFineiOSApp.swift
@@ -10,7 +10,7 @@ struct FeastFineiOSApp: App {
                 HomeView()
                     .environmentObject(appViewModel)
             } else {
-                LoginView()
+                LoginView(appViewModel: appViewModel)
                     .environmentObject(appViewModel)
             }
         }

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -5,12 +5,16 @@ final class AuthViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
     @Published var role: String = "user"
-    @Published var isAuthenticated: Bool = false
     @Published var errorMessage: String?
 
     private let service = AuthService()
     private let session = UserSession.shared
     private let userService = UserService()
+    private let appViewModel: AppViewModel
+
+    init(appViewModel: AppViewModel) {
+        self.appViewModel = appViewModel
+    }
 
     // MARK: - Actions
     func login() async {
@@ -21,7 +25,7 @@ final class AuthViewModel: ObservableObject {
             if let id = data.user?.id {
                 try await userService.fetchUserData(userId: id, role: role)
             }
-            isAuthenticated = true
+            appViewModel.isAuthenticated = true
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -55,7 +59,7 @@ final class AuthViewModel: ObservableObject {
     
     func logout() {
         service.logout()
-        isAuthenticated = false
+        appViewModel.isAuthenticated = false
     }
 }
 

--- a/IOS/Features/Auth/LoginView.swift
+++ b/IOS/Features/Auth/LoginView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
 struct LoginView: View {
-    @StateObject private var viewModel = AuthViewModel()
-    @EnvironmentObject var appViewModel: AppViewModel
+    @StateObject private var viewModel: AuthViewModel
+
+    init(appViewModel: AppViewModel) {
+        _viewModel = StateObject(wrappedValue: AuthViewModel(appViewModel: appViewModel))
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -16,9 +19,6 @@ struct LoginView: View {
             Button("Login") {
                 Task {
                     await viewModel.login()
-                    if viewModel.isAuthenticated {
-                        appViewModel.isAuthenticated = true
-                    }
                 }
             }
         }
@@ -27,6 +27,6 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView()
+    LoginView(appViewModel: AppViewModel())
 }
 


### PR DESCRIPTION
## Summary
- inject AppViewModel into AuthViewModel
- update login/logout to set shared auth state
- pass AppViewModel to LoginView from app entry point

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f6188e10c8323b83046c9b83ce7e4