### PR TITLE
Ensure secure HTTPS configuration

### DIFF
--- a/IOS/Core/AppConfiguration.swift
+++ b/IOS/Core/AppConfiguration.swift
@@ -20,9 +20,12 @@ enum AppConfiguration {
     }()
 
     static var apiBaseURL: URL {
-        guard let urlString = info["API_BASE_URL"] as? String,
-              let url = URL(string: urlString) else {
-            fatalError("API_BASE_URL not set")
+        guard
+            let urlString = info["API_BASE_URL"] as? String,
+            let url = URL(string: urlString),
+            url.scheme?.lowercased() == "https"
+        else {
+            fatalError("API_BASE_URL must be a valid https URL")
         }
         return url
     }

--- a/IOS/Info.plist
+++ b/IOS/Info.plist
@@ -27,9 +27,6 @@
         <string>UIInterfaceOrientationPortrait</string>
     </array>
     <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSAllowsArbitraryLoads</key>
-        <false/>
-    </dict>
+    <dict/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Enforce that `API_BASE_URL` resolves to an `https` URL
- Remove `NSAllowsArbitraryLoads` to tighten App Transport Security

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f64b8a0b08323afdadc6babfc5908