### PR TITLE
Handle wrapped API responses and empty body

### DIFF
--- a/IOS/Core/GenericResponse.swift
+++ b/IOS/Core/GenericResponse.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct GenericResponse<T: Decodable>: Decodable {
+    let success: Bool
+    let code: String?
+    let message: String?
+    let data: T?
+}

--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -25,4 +25,50 @@ final class APIClientTests: XCTestCase {
             XCTAssertEqual(error as? APIError, .notFound)
         }
     }
+
+    func testDecodesWrappedResponse() async throws {
+        struct Sample: Decodable { let value: String }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let body = "{""success"":true,""data"":{""value"":""test""}}"
+            return (response, Data(body.utf8))
+        }
+
+        let client = APIClient(baseURL: URL(string: "https://example.com/api")!, session: session)
+        let sample: Sample = try await client.request("wrapped")
+        XCTAssertEqual(sample.value, "test")
+    }
+
+    func testEmptyBodyReturnsEmptyResponse() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let client = APIClient(baseURL: URL(string: "https://example.com/api")!, session: session)
+        _ = try await client.request("empty") as EmptyResponse
+    }
+
+    func testWrappedFailureThrowsAPIError() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let body = "{""success"":false,""message"":""bad""}"
+            return (response, Data(body.utf8))
+        }
+
+        let client = APIClient(baseURL: URL(string: "https://example.com/api")!, session: session)
+        await XCTAssertThrowsError(try await client.request("fail") as EmptyResponse) { error in
+            XCTAssertEqual(error as? APIError, .badRequest("bad"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand APIClient to try decoding desired type, then GenericResponse wrapper
- tolerate empty body for EmptyResponse and surface backend failure when `success` is false
- add tests for wrapped responses and empty-body behavior

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a188abc8323813c1fe5e6bba545