### PR TITLE
Use EmptyResponse for service calls

### DIFF
--- a/IOS/Core/EmptyResponse.swift
+++ b/IOS/Core/EmptyResponse.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+struct EmptyResponse: Decodable {}

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -34,7 +34,7 @@ final class AuthViewModel: ObservableObject {
 
     func sendVerificationCode(email: String) async {
         do {
-            try await service.sendVerificationCode(email: email)
+            _ = try await service.sendVerificationCode(email: email)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -51,7 +51,7 @@ final class AuthViewModel: ObservableObject {
 
     func updateUser(email: String, password: String, role: String) async {
         do {
-            try await service.updateUser(email: email, password: password, role: role)
+            _ = try await service.updateUser(email: email, password: password, role: role)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/IOS/Features/Lists/ListsViewModel.swift
+++ b/IOS/Features/Lists/ListsViewModel.swift
@@ -32,7 +32,7 @@ final class ListsViewModel: ObservableObject {
     func removeList(_ id: String) async {
         guard let userId = session.getUserId() else { return }
         do {
-            try await service.removeList(userId: userId, listId: id)
+            _ = try await service.removeList(userId: userId, listId: id)
             lists.removeAll { $0.id == id }
             errorMessage = nil
         } catch {

--- a/IOS/Features/Reviews/ReviewsViewModel.swift
+++ b/IOS/Features/Reviews/ReviewsViewModel.swift
@@ -22,7 +22,7 @@ final class ReviewsViewModel: ObservableObject {
         guard let userId = session.getUserId() else { return }
         let request = ReviewRequest(rating: rating, comment: comment)
         do {
-            try await service.newReview(userId: userId, businessId: businessId, review: request)
+            _ = try await service.newReview(userId: userId, businessId: businessId, review: request)
             await loadReviews()
         } catch {
             errorMessage = error.localizedDescription

--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import IOS
 
-private struct EmptyResponse: Decodable {}
 
 final class APIClientTests: XCTestCase {
     func testRequestToInsecureURLThrows() async {

--- a/IOS/Services/AuthService.swift
+++ b/IOS/Services/AuthService.swift
@@ -6,9 +6,10 @@ final class AuthService {
     private let authStorageKey = "authData"
 
     // MARK: - Networking
-    func sendVerificationCode(email: String) async throws {
+    func sendVerificationCode(email: String) async throws -> EmptyResponse {
         let body = try JSONEncoder().encode(["email": email])
-        let _: EmptyResponse = try await api.request("api/auth/send-verification-code", method: "POST", body: body)
+        let response: EmptyResponse = try await api.request("api/auth/send-verification-code", method: "POST", body: body)
+        return response
     }
 
     func verifyCode(email: String, token: String) async throws -> VerificationResponse {
@@ -17,9 +18,10 @@ final class AuthService {
         return response
     }
 
-    func updateUser(email: String, password: String, role: String) async throws {
+    func updateUser(email: String, password: String, role: String) async throws -> EmptyResponse {
         let body = try JSONEncoder().encode(["email": email, "password": password, "role": role])
-        let _: EmptyResponse = try await api.request("api/auth/update-user", method: "POST", body: body)
+        let response: EmptyResponse = try await api.request("api/auth/update-user", method: "POST", body: body)
+        return response
     }
 
     func login(email: String, password: String, role: String) async throws -> AuthData {
@@ -50,5 +52,4 @@ final class AuthService {
     }
 }
 
-private struct EmptyResponse: Decodable {}
 

--- a/IOS/Services/BusinessService.swift
+++ b/IOS/Services/BusinessService.swift
@@ -58,12 +58,12 @@ final class BusinessService {
         return PromotionMapper.map(dto)
     }
 
-    func deletePromotion(_ businessId: String, promotionId: String) async throws {
-        let _: EmptyResponse = try await api.request("\(base)/promotions/\(businessId)/\(promotionId)", method: "DELETE")
+    func deletePromotion(_ businessId: String, promotionId: String) async throws -> EmptyResponse {
+        return try await api.request("\(base)/promotions/\(businessId)/\(promotionId)", method: "DELETE")
     }
 
-    func setViewed(_ reviewId: String) async throws {
-        let _: EmptyResponse = try await api.request("\(base)/reviews/\(reviewId)", method: "PATCH")
+    func setViewed(_ reviewId: String) async throws -> EmptyResponse {
+        return try await api.request("\(base)/reviews/\(reviewId)", method: "PATCH")
     }
 }
 
@@ -106,4 +106,3 @@ private func encodePromotionRequest(_ promotion: PromotionRequest) throws -> Dat
     return try JSONEncoder().encode(request)
 }
 
-private struct EmptyResponse: Decodable {}

--- a/IOS/Services/ListService.swift
+++ b/IOS/Services/ListService.swift
@@ -25,19 +25,19 @@ final class ListService {
         return "api/users/\(role)"
     }
 
-    func addToList(userId: String, listId: String, itemId: String) async throws {
+    func addToList(userId: String, listId: String, itemId: String) async throws -> EmptyResponse {
         let path = "\(base)/\(userId)/lists/\(listId)/items/\(itemId)"
-        let _: EmptyResponse = try await api.request(path, method: "POST")
+        return try await api.request(path, method: "POST")
     }
 
-    func addToFavorites(userId: String, itemId: String) async throws {
-        guard let favoritesId = userService.getUserFavoritesIdFromStorage() else { return }
-        try await addToList(userId: userId, listId: favoritesId, itemId: itemId)
+    func addToFavorites(userId: String, itemId: String) async throws -> EmptyResponse {
+        guard let favoritesId = userService.getUserFavoritesIdFromStorage() else { return EmptyResponse() }
+        return try await addToList(userId: userId, listId: favoritesId, itemId: itemId)
     }
 
-    func removeFromList(userId: String, listId: String, itemId: String) async throws {
+    func removeFromList(userId: String, listId: String, itemId: String) async throws -> EmptyResponse {
         let path = "\(base)/\(userId)/lists/\(listId)/items/\(itemId)"
-        let _: EmptyResponse = try await api.request(path, method: "DELETE")
+        return try await api.request(path, method: "DELETE")
     }
 
     func createList(userId: String, name: String, isPublic: Bool) async throws -> UserList {
@@ -46,9 +46,9 @@ final class ListService {
         return try await api.request(path, method: "POST", body: body)
     }
 
-    func removeList(userId: String, listId: String) async throws {
+    func removeList(userId: String, listId: String) async throws -> EmptyResponse {
         let path = "\(base)/\(userId)/lists/\(listId)"
-        let _: EmptyResponse = try await api.request(path, method: "DELETE")
+        return try await api.request(path, method: "DELETE")
     }
 
     func updateList(userId: String, listId: String, name: String, isPublic: Bool) async throws -> UserList {
@@ -79,16 +79,15 @@ final class ListService {
         let isFavorited = favorites.contains { $0.id == itemId }
 
         if isFavorited {
-            try await removeFromList(userId: userId, listId: favoritesId, itemId: itemId)
+            _ = try await removeFromList(userId: userId, listId: favoritesId, itemId: itemId)
         } else {
-            try await addToFavorites(userId: userId, itemId: itemId)
+            _ = try await addToFavorites(userId: userId, itemId: itemId)
         }
 
         return try await getUserListItems(userId: userId, listId: favoritesId)
     }
 }
 
-private struct EmptyResponse: Decodable {}
 
 private struct ListRequest: Encodable {
     let name: String

--- a/IOS/Services/UserService.swift
+++ b/IOS/Services/UserService.swift
@@ -95,9 +95,9 @@ final class UserService {
 
     // MARK: - Remote Operations
     /// Requests a password change for the specified user.
-    func changePassword(userId: String, newPassword: String) async throws {
+    func changePassword(userId: String, newPassword: String) async throws -> EmptyResponse {
         let body = try JSONEncoder().encode(["newPassword": newPassword])
-        let _: EmptyResponse = try await api.request("\(base)/\(userId)/change-password", method: "PATCH", body: body)
+        return try await api.request("\(base)/\(userId)/change-password", method: "PATCH", body: body)
     }
 
     /// Fetches profile information for the given user identifier.
@@ -111,19 +111,19 @@ final class UserService {
     }
 
     /// Adds a like to a list for the user.
-    func addLike(userId: String, listId: String) async throws {
-        let _: EmptyResponse = try await api.request("\(base)/diner_user/\(userId)/like/\(listId)", method: "POST")
+    func addLike(userId: String, listId: String) async throws -> EmptyResponse {
+        return try await api.request("\(base)/diner_user/\(userId)/like/\(listId)", method: "POST")
     }
 
     /// Removes a like from a list for the user.
-    func removeLike(userId: String, listId: String) async throws {
-        let _: EmptyResponse = try await api.request("\(base)/diner_user/\(userId)/unlike/\(listId)", method: "DELETE")
+    func removeLike(userId: String, listId: String) async throws -> EmptyResponse {
+        return try await api.request("\(base)/diner_user/\(userId)/unlike/\(listId)", method: "DELETE")
     }
 
     /// Creates a new review for a business.
-    func newReview(userId: String, businessId: String, review: ReviewRequest) async throws {
+    func newReview(userId: String, businessId: String, review: ReviewRequest) async throws -> EmptyResponse {
         let body = try JSONEncoder().encode(review)
-        let _: EmptyResponse = try await api.request("\(base)/diner_user/\(userId)/reviews/\(businessId)", method: "POST", body: body)
+        return try await api.request("\(base)/diner_user/\(userId)/reviews/\(businessId)", method: "POST", body: body)
     }
 
     /// Retrieves reviews written by the user.
@@ -153,7 +153,6 @@ private struct UserProfileResponse: Decodable {
     let dinerLists: [UserList]?
 }
 
-private struct EmptyResponse: Decodable {}
 
 private struct DinerUpdateRequest: Codable {
     let email: String?


### PR DESCRIPTION
## Summary
- add shared `EmptyResponse` model
- return `EmptyResponse` from service methods instead of `Void`
- adjust view models and tests to use the new response type

## Testing
- `swift test` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f6c178900832380fa4cec528e548a