### PR TITLE
Use like_counter key in user list

### DIFF
--- a/IOS/Services/ListService.swift
+++ b/IOS/Services/ListService.swift
@@ -11,7 +11,7 @@ struct UserList: Identifiable, Decodable {
         case id, name
         case isFavorite = "is_favorite"
         case isPublic = "is_public"
-        case likeCount = "like_count"
+        case likeCount = "like_counter"
     }
 }
 


### PR DESCRIPTION
## Summary
- align UserList likeCount coding key with `like_counter`

## Testing
- `swift test` *(fails: unable to clone https://github.com/supabase-community/supabase-swift.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f6ee532148323afe6afc0fb08900e