### PR TITLE
Handle nested review info in BusinessService

### DIFF
--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -67,6 +67,11 @@ struct ReviewDTO: Decodable {
     let comment: String?
 }
 
+struct ReviewInfoDTO: Decodable {
+    let review: ReviewDTO
+    let reviewerName: String
+}
+
 // MARK: - Domain models
 struct Business: Identifiable {
     let id: String
@@ -142,12 +147,12 @@ enum PromotionMapper {
 }
 
 enum ReviewMapper {
-    static func map(_ dto: ReviewDTO) -> Review {
+    static func map(_ dto: ReviewInfoDTO) -> Review {
         Review(
-            id: dto.id,
-            reviewerName: dto.reviewerName ?? "",
-            rating: dto.rating,
-            comment: dto.comment ?? ""
+            id: dto.review.id,
+            reviewerName: dto.reviewerName,
+            rating: dto.review.rating,
+            comment: dto.review.comment ?? ""
         )
     }
 }

--- a/IOS/Services/BusinessService.swift
+++ b/IOS/Services/BusinessService.swift
@@ -37,7 +37,7 @@ final class BusinessService {
     }
 
     func getBusinessReviews(_ businessId: String) async throws -> [Review] {
-        let dtos: [ReviewDTO] = try await api.request("\(base)/reviews/\(businessId)")
+        let dtos: [ReviewInfoDTO] = try await api.request("\(base)/reviews/\(businessId)")
         return dtos.map(ReviewMapper.map)
     }
 


### PR DESCRIPTION
## Summary
- Introduce `ReviewInfoDTO` to encapsulate review data and reviewer name
- Decode `ReviewInfoDTO` in `BusinessService.getBusinessReviews`
- Map `ReviewInfoDTO` to domain `Review`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f7047691883239d9c63ce6f1d751d