### PR TITLE
fix: configure API root and clean service base paths

### DIFF
--- a/IOS/Configuration.plist
+++ b/IOS/Configuration.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>API_BASE_URL</key>
-    <string>https://example.com/api</string>
+    <string>https://example.com</string>
     <key>SUPABASE_URL</key>
     <string>https://your-project.supabase.co</string>
     <key>SUPABASE_ANON_KEY</key>

--- a/frontend/src/services/businessService.js
+++ b/frontend/src/services/businessService.js
@@ -1,7 +1,7 @@
 
 import axios from 'axios';
 
-const API_BASE = '/api/business';
+const API_BASE = 'api/business';
 
 /**
  * Fetches all businesses.

--- a/frontend/src/services/listService.js
+++ b/frontend/src/services/listService.js
@@ -3,7 +3,7 @@
 import axios from 'axios';
 import {getUserFavoritesIdFromStorage} from "./userService.js";
 
-const API_URL = '/api/users';
+const API_URL = 'api/users';
 
 export const addToList = async (userId, listId, itemId) => {
     const response = await axios.post(`${API_URL}/diner_user/${userId}/lists/${listId}/items/${itemId}`);

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = '/api/users';
+const API_URL = 'api/users';
 
 /**
  * save user data to local storage


### PR DESCRIPTION
## Summary
- point iOS API_BASE_URL to `https://example.com`
- trim leading slash from frontend service base paths to avoid duplicate `/api`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: ... 403)*
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run lint` *(fails: 44 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689f732567c083239ca80ef474fe74a8