### PR TITLE
Add Review info DTO and mapper

### DIFF
--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -67,6 +67,17 @@ struct ReviewDTO: Decodable {
     let comment: String?
 }
 
+struct ReviewInfoForBusinessDTO: Decodable {
+    let review: InnerReview
+    let reviewerName: String?
+
+    struct InnerReview: Decodable {
+        let id: String
+        let comment: String?
+        let rating: Double
+    }
+}
+
 // MARK: - Domain models
 struct Business: Identifiable {
     let id: String
@@ -148,6 +159,17 @@ enum ReviewMapper {
             reviewerName: dto.reviewerName ?? "",
             rating: dto.rating,
             comment: dto.comment ?? ""
+        )
+    }
+}
+
+enum ReviewInfoMapper {
+    static func map(_ dto: ReviewInfoForBusinessDTO) -> Review {
+        Review(
+            id: dto.review.id,
+            reviewerName: dto.reviewerName ?? "",
+            rating: dto.review.rating,
+            comment: dto.review.comment ?? ""
         )
     }
 }


### PR DESCRIPTION
## Summary
- define `ReviewInfoForBusinessDTO` with nested `InnerReview`
- add `ReviewInfoMapper` to convert review info to domain `Review`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f78229da48323963dbeb13378d3db