### PR TITLE
Use EmptyResponse for promotion updates and capture API messages

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -10,6 +10,7 @@ final class APIClient {
     private let baseURL: URL
     private let session: URLSession
     private var authData: AuthData?
+    private(set) var message: String?
 
     init(baseURL: URL = AppConfiguration.apiBaseURL,
          session: URLSession = .shared) {
@@ -26,6 +27,7 @@ final class APIClient {
     func request<T: Decodable>(_ path: String,
                                method: String = "GET",
                                body: Data? = nil) async throws -> T {
+        message = nil
         let url = baseURL.appendingPathComponent(path)
         guard url.scheme?.lowercased() == "https" else {
             throw APIClientError.insecureURL
@@ -61,6 +63,7 @@ final class APIClient {
             }
 
             let wrapped = try decoder.decode(GenericResponse<T>.self, from: data)
+            message = wrapped.message
             guard wrapped.success else {
                 throw APIError.badRequest(wrapped.message)
             }

--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -70,4 +70,19 @@ final class APIClientTests: XCTestCase {
             XCTAssertEqual(error as? APIError, .badRequest("bad"))
         }
     }
+
+    func testStoresMessageFromResponse() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let body = "{\"success\":true,\"message\":\"ok\"}"
+            return (response, Data(body.utf8))
+        }
+
+        let client = APIClient(baseURL: URL(string: "https://example.com/api")!, session: session)
+        _ = try await client.request("msg") as EmptyResponse
+        XCTAssertEqual(client.message, "ok")
+    }
 }

--- a/IOS/Services/BusinessService.swift
+++ b/IOS/Services/BusinessService.swift
@@ -54,24 +54,22 @@ final class BusinessService {
 
     func updatePromotion(_ businessId: String, promotionId: String, promotion: PromotionRequest) async throws {
         let body = try encodePromotionRequest(promotion)
-        let response: GenericResponse<EmptyResponse> = try await api.request(
+        try await api.request(
             "\(base)/promotions/\(businessId)/\(promotionId)",
             method: "PATCH",
             body: body
-        )
-        guard response.success else { throw APIError.badRequest(response.message) }
-        if let message = response.message {
+        ) as EmptyResponse
+        if let message = api.message {
             print(message)
         }
     }
 
     func deletePromotion(_ businessId: String, promotionId: String) async throws {
-        let response: GenericResponse<EmptyResponse> = try await api.request(
+        try await api.request(
             "\(base)/promotions/\(businessId)/\(promotionId)",
             method: "DELETE"
-        )
-        guard response.success else { throw APIError.badRequest(response.message) }
-        if let message = response.message {
+        ) as EmptyResponse
+        if let message = api.message {
             print(message)
         }
     }


### PR DESCRIPTION
## Summary
- Refactor updatePromotion and deletePromotion to request `EmptyResponse`
- Expose optional `message` on APIClient and capture it from wrapped responses
- Add unit test for APIClient message handling

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ba0a4ec832383c75523b61b92b6