### PR TITLE
Return EmptyResponse without decoding

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -54,8 +54,8 @@ final class APIClient {
         case 200..<300:
             let decoder = JSONDecoder()
 
-            if data.isEmpty, String(describing: T.self) == "EmptyResponse" {
-                return try decoder.decode(T.self, from: Data("{}".utf8))
+            if data.isEmpty && T.self == EmptyResponse.self {
+                return EmptyResponse() as! T
             }
 
             if let direct = try? decoder.decode(T.self, from: data) {
@@ -72,8 +72,8 @@ final class APIClient {
                 return payload
             }
 
-            if String(describing: T.self) == "EmptyResponse" {
-                return try decoder.decode(T.self, from: Data("{}".utf8))
+            if T.self == EmptyResponse.self {
+                return EmptyResponse() as! T
             }
 
             throw APIError.unknown(statusCode: http.statusCode, message: wrapped.message)


### PR DESCRIPTION
## Summary
- avoid decoding when response type is EmptyResponse

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f7cedbef083238969305cc20a01c7