### PR TITLE
Clarify HTTP test limitations

### DIFF
--- a/IOS/IOSTests/APIClientTests.swift
+++ b/IOS/IOSTests/APIClientTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class APIClientTests: XCTestCase {
     func testRequestToInsecureURLThrows() async {
+        // This test intentionally uses HTTP to verify insecure URL handling.
+        // Without an ATS exception in Info.plist, it cannot run on a real device.
         let client = APIClient(baseURL: URL(string: "http://example.com/api")!)
         await XCTAssertThrowsError(try await client.request("test") as EmptyResponse) { error in
             XCTAssertEqual(error as? APIClientError, .insecureURL)

--- a/IOS/Info.plist
+++ b/IOS/Info.plist
@@ -26,6 +26,7 @@
     <array>
         <string>UIInterfaceOrientationPortrait</string>
     </array>
+    <!-- No ATS exceptions defined; HTTP-based tests will not run on real devices -->
     <key>NSAppTransportSecurity</key>
     <dict/>
 </dict>


### PR DESCRIPTION
## Summary
- clarify that APIClient insecure URL test uses HTTP intentionally and note ATS requirements
- note in Info.plist that no ATS exceptions are present, so HTTP tests won't run on real devices

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f824de39483238681cb9d4d63e2e1