### PR TITLE
Add search and filter support to BusinessViewModel and HomeView

### DIFF
--- a/IOS/Features/BusinessViewModel.swift
+++ b/IOS/Features/BusinessViewModel.swift
@@ -2,27 +2,20 @@ import Foundation
 
 @MainActor
 final class BusinessViewModel: ObservableObject {
-    @Published var businesses: [Restaurant] = []
     @Published var topRated: [Restaurant] = []
+    @Published var searchResults: [Restaurant] = []
     @Published var selectedBusiness: Restaurant?
     @Published var promotions: [Promotion] = []
     @Published var reviews: [Review] = []
     @Published var errorMessage: String?
     @Published var searchTerm: String = ""
+    @Published var selectedFilter: FilterType?
 
     private let service = BusinessService()
 
-    func fetchAll() async {
+    func fetchTopRated(limit: Int = 5) async {
         do {
-            businesses = try await service.getAllBusinesses()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    func fetchTopRated() async {
-        do {
-            topRated = try await service.getTopRated()
+            topRated = try await service.getTopRated(limit: limit)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -31,9 +24,25 @@ final class BusinessViewModel: ObservableObject {
     func search() async {
         do {
             if searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                businesses = try await service.getAllBusinesses()
+                searchResults = try await service.getAllBusinesses()
             } else {
-                businesses = try await service.searchBusinesses(searchTerm)
+                searchResults = try await service.searchBusinesses(searchTerm)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func applyFilter() async {
+        guard let filter = selectedFilter else {
+            await search()
+            return
+        }
+        do {
+            if filter == .all {
+                await search()
+            } else if let tag = filter.tagId {
+                searchResults = try await service.getByTag(tag)
             }
         } catch {
             errorMessage = error.localizedDescription
@@ -61,6 +70,47 @@ final class BusinessViewModel: ObservableObject {
             reviews = try await service.getBusinessReviews(businessId)
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+}
+
+enum FilterType: String, CaseIterable {
+    case all
+    case wine
+    case pizza
+    case coffee
+    case burger
+    case cafe
+    case promo
+
+    var icon: String {
+        switch self {
+        case .all: return "line.3.horizontal.decrease.circle"
+        case .wine: return "wineglass"
+        case .pizza: return "takeoutbag.and.cup.and.straw"
+        case .coffee: return "cup.and.saucer"
+        case .burger: return "fork.knife"
+        case .cafe: return "building.2"
+        case .promo: return "tag"
+        }
+    }
+
+    var tagId: String? {
+        switch self {
+        case .all:
+            return nil
+        case .wine:
+            return "wine"
+        case .pizza:
+            return "pizza"
+        case .coffee:
+            return "coffee"
+        case .burger:
+            return "burgers"
+        case .cafe:
+            return "cafe"
+        case .promo:
+            return "promo"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add state for search results, filter type and search term in `BusinessViewModel`
- implement `fetchTopRated(limit:)`, `search()` and filter handling via `getByTag`
- update `HomeView` to use new search/filter state and present errors via alert

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8b32ccb88323bc697a99d472ca95