### PR TITLE
Add authentication toolbar with profile navigation

### DIFF
--- a/IOS/FeastFineiOSApp.swift
+++ b/IOS/FeastFineiOSApp.swift
@@ -2,12 +2,20 @@ import SwiftUI
 
 @main
 struct FeastFineiOSApp: App {
-    @StateObject private var appViewModel = AppViewModel()
+    @StateObject private var appViewModel: AppViewModel
+    @StateObject private var authViewModel: AuthViewModel
+
+    init() {
+        let appVM = AppViewModel()
+        _appViewModel = StateObject(wrappedValue: appVM)
+        _authViewModel = StateObject(wrappedValue: AuthViewModel(appViewModel: appVM))
+    }
 
     var body: some Scene {
         WindowGroup {
             HomeView()
                 .environmentObject(appViewModel)
+                .environmentObject(authViewModel)
         }
     }
 }

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -6,6 +6,7 @@ final class AuthViewModel: ObservableObject {
     @Published var password: String = ""
     @Published var role: String = "user"
     @Published var errorMessage: String?
+    @Published var isAuthenticated: Bool
 
     private let service = AuthService()
     private let session = UserSession.shared
@@ -14,6 +15,7 @@ final class AuthViewModel: ObservableObject {
 
     init(appViewModel: AppViewModel) {
         self.appViewModel = appViewModel
+        self.isAuthenticated = appViewModel.isAuthenticated
     }
 
     // MARK: - Actions
@@ -26,6 +28,7 @@ final class AuthViewModel: ObservableObject {
                 try await userService.fetchUserData(userId: id, role: role)
             }
             appViewModel.isAuthenticated = true
+            isAuthenticated = true
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -60,6 +63,7 @@ final class AuthViewModel: ObservableObject {
     func logout() {
         service.logout()
         appViewModel.isAuthenticated = false
+        isAuthenticated = false
     }
 }
 

--- a/IOS/Features/Auth/LoginView.swift
+++ b/IOS/Features/Auth/LoginView.swift
@@ -1,12 +1,8 @@
 import SwiftUI
 
 struct LoginView: View {
-    @StateObject private var viewModel: AuthViewModel
-
-    init(appViewModel: AppViewModel) {
-        _viewModel = StateObject(wrappedValue: AuthViewModel(appViewModel: appViewModel))
-    }
-
+    @EnvironmentObject private var viewModel: AuthViewModel
+    
     var body: some View {
         VStack(spacing: 16) {
             TextField("Email", text: $viewModel.email)
@@ -27,6 +23,9 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView(appViewModel: AppViewModel())
+    let appVM = AppViewModel()
+    let authVM = AuthViewModel(appViewModel: appVM)
+    return LoginView()
+        .environmentObject(appVM)
+        .environmentObject(authVM)
 }
-


### PR DESCRIPTION
## Summary
- Add shared AuthViewModel with authentication state and link it to AppViewModel
- Display login button or profile icon in HomeView toolbar and open Login or Profile views
- Provide AuthViewModel throughout the app via FeastFineiOSApp

## Testing
- `swift test` *(fails: unable to access https://github.com/supabase-community/supabase-swift.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f8f6ea3588323bf825261656fe3c8