### PR TITLE
Display login or home based on authentication state

### DIFF
--- a/IOS/FeastFineiOSApp.swift
+++ b/IOS/FeastFineiOSApp.swift
@@ -13,9 +13,15 @@ struct FeastFineiOSApp: App {
 
     var body: some Scene {
         WindowGroup {
-            HomeView()
-                .environmentObject(appViewModel)
-                .environmentObject(authViewModel)
+            Group {
+                if appViewModel.isAuthenticated {
+                    HomeView()
+                } else {
+                    LoginView()
+                }
+            }
+            .environmentObject(appViewModel)
+            .environmentObject(authViewModel)
         }
     }
 }

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -16,6 +16,12 @@ final class AuthViewModel: ObservableObject {
     init(appViewModel: AppViewModel) {
         self.appViewModel = appViewModel
         self.isAuthenticated = appViewModel.isAuthenticated
+
+        if let auth = service.getAuthData() {
+            session.save(userId: auth.user?.id, token: auth.accessToken)
+            appViewModel.isAuthenticated = true
+            isAuthenticated = true
+        }
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- Switch root view between `LoginView` and `HomeView` based on authentication status.
- Sync `AppViewModel.isAuthenticated` on startup using any stored auth token.
- Keep app authentication state updated on login and logout actions.

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f9c5ae1c08323b25a2a729df764cf