### PR TITLE
Add list and favorite management actions

### DIFF
--- a/IOS/Features/Favorites/FavoritesView.swift
+++ b/IOS/Features/Favorites/FavoritesView.swift
@@ -5,15 +5,29 @@ struct FavoritesView: View {
 
     var body: some View {
         List(viewModel.favorites) { restaurant in
-            Text(restaurant.name)
+            HStack {
+                Text(restaurant.name)
+                Spacer()
+                Button {
+                    Task { await viewModel.removeFavorite(restaurant.id) }
+                } label: {
+                    Image(systemName: "heart.slash")
+                        .foregroundColor(.red)
+                }
+            }
         }
         .navigationTitle("Favorites")
         .task {
             await viewModel.loadFavorites()
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
+            VStack {
+                if let status = viewModel.statusMessage {
+                    Text(status).foregroundColor(.green)
+                }
+                if let error = viewModel.errorMessage {
+                    Text(error).foregroundColor(.red)
+                }
             }
         }
     }

--- a/IOS/Features/Favorites/FavoritesViewModel.swift
+++ b/IOS/Features/Favorites/FavoritesViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [Restaurant] = []
     @Published var errorMessage: String?
+    @Published var statusMessage: String?
 
     private let service = ListService()
     private let userService = UserService()
@@ -15,8 +16,22 @@ final class FavoritesViewModel: ObservableObject {
         do {
             favorites = try await service.getUserListItems(userId: userId, listId: favoritesId)
             errorMessage = nil
+            statusMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            statusMessage = nil
+        }
+    }
+
+    func removeFavorite(_ id: String) async {
+        guard let userId = session.getUserId() else { return }
+        do {
+            favorites = try await service.toggleFavorite(userId: userId, itemId: id)
+            statusMessage = "Removed from favorites"
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            statusMessage = nil
         }
     }
 }

--- a/IOS/Features/InsideList/InsideListView.swift
+++ b/IOS/Features/InsideList/InsideListView.swift
@@ -6,15 +6,29 @@ struct InsideListView: View {
 
     var body: some View {
         List(viewModel.items) { restaurant in
-            Text(restaurant.name)
+            HStack {
+                Text(restaurant.name)
+                Spacer()
+                Button {
+                    Task { await viewModel.removeItem(listId: list.id, itemId: restaurant.id) }
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
+                }
+            }
         }
         .navigationTitle(list.name)
         .task {
             await viewModel.loadItems(listId: list.id)
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
+            VStack {
+                if let status = viewModel.statusMessage {
+                    Text(status).foregroundColor(.green)
+                }
+                if let error = viewModel.errorMessage {
+                    Text(error).foregroundColor(.red)
+                }
             }
         }
     }

--- a/IOS/Features/InsideList/InsideListViewModel.swift
+++ b/IOS/Features/InsideList/InsideListViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 final class InsideListViewModel: ObservableObject {
     @Published var items: [Restaurant] = []
     @Published var errorMessage: String?
+    @Published var statusMessage: String?
 
     private let service = ListService()
     private let session = UserSession.shared
@@ -13,8 +14,23 @@ final class InsideListViewModel: ObservableObject {
         do {
             items = try await service.getUserListItems(userId: userId, listId: listId)
             errorMessage = nil
+            statusMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            statusMessage = nil
+        }
+    }
+
+    func removeItem(listId: String, itemId: String) async {
+        guard let userId = session.getUserId() else { return }
+        do {
+            _ = try await service.removeFromList(userId: userId, listId: listId, itemId: itemId)
+            await loadItems(listId: listId)
+            statusMessage = "Item removed"
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            statusMessage = nil
         }
     }
 }

--- a/IOS/Features/Lists/ListsView.swift
+++ b/IOS/Features/Lists/ListsView.swift
@@ -15,12 +15,12 @@ struct ListsView: View {
                             if list.isFavorite == true {
                                 Image(systemName: "star.fill").foregroundColor(.yellow)
                             }
-                        }
-                    }
-                    .onDelete { indexSet in
-                        for index in indexSet {
-                            let id = viewModel.lists[index].id
-                            Task { await viewModel.removeList(id) }
+                            Button {
+                                Task { await viewModel.removeList(list.id) }
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                            }
                         }
                     }
                 }
@@ -34,6 +34,9 @@ struct ListsView: View {
                     }
                 }
                 .padding()
+                if let status = viewModel.statusMessage {
+                    Text(status).foregroundColor(.green)
+                }
                 if let message = viewModel.errorMessage {
                     Text(message).foregroundColor(.red)
                 }

--- a/IOS/Features/Lists/ListsViewModel.swift
+++ b/IOS/Features/Lists/ListsViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 final class ListsViewModel: ObservableObject {
     @Published var lists: [UserList] = []
     @Published var errorMessage: String?
+    @Published var statusMessage: String?
 
     private let service = ListService()
     private let session = UserSession.shared
@@ -13,19 +14,23 @@ final class ListsViewModel: ObservableObject {
         do {
             lists = try await service.getUserLists(userId: userId)
             errorMessage = nil
+            statusMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            statusMessage = nil
         }
     }
 
     func createList(name: String, isPublic: Bool = false) async {
         guard let userId = session.getUserId() else { return }
         do {
-            let newList = try await service.createList(userId: userId, name: name, isPublic: isPublic)
-            lists.append(newList)
+            _ = try await service.createList(userId: userId, name: name, isPublic: isPublic)
+            await loadLists()
+            statusMessage = "List created"
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            statusMessage = nil
         }
     }
 
@@ -33,10 +38,12 @@ final class ListsViewModel: ObservableObject {
         guard let userId = session.getUserId() else { return }
         do {
             _ = try await service.removeList(userId: userId, listId: id)
-            lists.removeAll { $0.id == id }
+            await loadLists()
+            statusMessage = "List removed"
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            statusMessage = nil
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add status messaging to list and favorite view models and refresh data after actions
- Allow removing lists, list items, and favorites via new buttons

## Testing
- `swift test` *(fails: Unable to access https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fa2ca610083239dbbf4595efbc4cc