### PR TITLE
feat: add favorites toggle and refresh

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -2,29 +2,43 @@ import SwiftUI
 
 struct RestaurantRow: View {
     let restaurant: Restaurant
+    @EnvironmentObject var listViewModel: BusinessViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(restaurant.name)
-                .font(.headline)
-            HStack {
-                Text("⭐️ \(String(format: "%.1f", restaurant.rating))")
-                Text(restaurant.priceRange)
-            }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(restaurant.name)
+                    .font(.headline)
+                HStack {
+                    Text("⭐️ \(String(format: "%.1f", restaurant.rating))")
+                    Text(restaurant.priceRange)
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
 
-            if let address = restaurant.address {
-                Text("\(address.street), \(address.city)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                if let address = restaurant.address {
+                    Text("\(address.street), \(address.city)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
-            if !restaurant.tags.isEmpty {
-                Text(restaurant.tags.map { $0.name }.joined(separator: ", "))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                if !restaurant.tags.isEmpty {
+                    Text(restaurant.tags.map { $0.name }.joined(separator: ", "))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
+            Spacer()
+            Button {
+                Task {
+                    await listViewModel.toggleFavorite(restaurant.id)
+                    await listViewModel.refreshFavorites()
+                }
+            } label: {
+                Image(systemName: listViewModel.favoriteIds.contains(restaurant.id) ? "heart.fill" : "heart")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
         }
     }
 }
@@ -42,4 +56,5 @@ struct RestaurantRow: View {
             promotions: []
         )
     )
+    .environmentObject(BusinessViewModel())
 }

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -45,6 +45,7 @@ struct HomeView: View {
                                     NavigationLink(destination: RestaurantDetailView(businessId: business.id)) {
                                         RestaurantRow(restaurant: business)
                                             .frame(width: 200)
+                                            .environmentObject(viewModel)
                                     }
                                 }
                             }
@@ -59,6 +60,7 @@ struct HomeView: View {
                         ForEach(viewModel.searchResults) { business in
                             NavigationLink(destination: RestaurantDetailView(businessId: business.id)) {
                                 RestaurantRow(restaurant: business)
+                                    .environmentObject(viewModel)
                             }
                         }
                     }
@@ -92,6 +94,7 @@ struct HomeView: View {
             .task {
                 await viewModel.fetchTopRated()
                 await viewModel.search()
+                await viewModel.refreshFavorites()
             }
             .onReceive(locationManager.$userLocation.compactMap { $0 }) { location in
                 viewModel.userLocation = location


### PR DESCRIPTION
## Summary
- add heart button to restaurant rows and toggle favorites
- track favorite ids in business view model with refresh support
- refresh favorites after toggling and on home load

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fae008d5083238c8ed1ed91caea55