### PR TITLE
Add filtering & sorting controls to business search

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -51,6 +51,7 @@ struct RestaurantRow: View {
             description: "",
             priceRange: "$$",
             rating: 4.5,
+            distance: 1500,
             address: Address(id: "a1", street: "Main St", city: "City", district: "District", neighborhood: "Neighborhood"),
             tags: [Tag(id: "t1", name: "Fast Food")],
             promotions: []

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -8,6 +8,7 @@ struct HomeView: View {
     @StateObject private var locationManager = LocationManager()
     @State private var showLogin = false
     @State private var showProfile = false
+    @State private var showAddressSheet = false
 
     var body: some View {
         NavigationView {
@@ -17,6 +18,38 @@ struct HomeView: View {
                         HStack {
                             TextField("Ara", text: $viewModel.searchTerm)
                                 .textFieldStyle(.roundedBorder)
+
+                            Menu {
+                                Section("Fiyat") {
+                                    Button("$") { viewModel.priceRangeFilter = "$"; viewModel.applyFiltersAndSort() }
+                                    Button("$$") { viewModel.priceRangeFilter = "$$"; viewModel.applyFiltersAndSort() }
+                                    Button("$$$") { viewModel.priceRangeFilter = "$$$"; viewModel.applyFiltersAndSort() }
+                                }
+                                Section("Promosyon") {
+                                    Button("Var") { viewModel.hasActivePromoFilter = true; viewModel.applyFiltersAndSort() }
+                                    Button("Yok") { viewModel.hasActivePromoFilter = false; viewModel.applyFiltersAndSort() }
+                                }
+                                Section {
+                                    Button("Adres") { showAddressSheet = true }
+                                    Button("Temizle") { viewModel.clearFilters() }
+                                }
+                            } label: {
+                                Image(systemName: "line.3.horizontal.decrease.circle")
+                                    .padding(8)
+                            }
+
+                            Menu {
+                                ForEach(SortOption.allCases, id: \.self) { option in
+                                    Button(option.rawValue.capitalized) {
+                                        viewModel.sortOption = option
+                                        viewModel.applyFiltersAndSort()
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "arrow.up.arrow.down")
+                                    .padding(8)
+                            }
+
                             Button("Ara") {
                                 Task { await viewModel.search() }
                             }
@@ -90,6 +123,30 @@ struct HomeView: View {
             }
             .sheet(isPresented: $showProfile) {
                 ProfileView()
+            }
+            .sheet(isPresented: $showAddressSheet) {
+                NavigationView {
+                    Form {
+                        Section("Adres") {
+                            TextField("City", text: $viewModel.addressFilter.city)
+                            TextField("District", text: $viewModel.addressFilter.district)
+                            TextField("Neighborhood", text: $viewModel.addressFilter.neighborhood)
+                            TextField("Street", text: $viewModel.addressFilter.street)
+                        }
+                    }
+                    .navigationTitle("Adres Filtrele")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") {
+                                showAddressSheet = false
+                                viewModel.applyFiltersAndSort()
+                            }
+                        }
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { showAddressSheet = false }
+                        }
+                    }
+                }
             }
             .task {
                 await viewModel.fetchTopRated()

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -10,6 +10,11 @@ struct BusinessDTO: Decodable, Identifiable {
     let address: AddressDTO?
     let tags: [TagDTO]
     let promotions: [PromotionDTO]
+    /// Optional distance in meters from the user's location. Some endpoints
+    /// such as `/nearby` include this value which can then be used for sorting
+    /// purposes on the client side. When not provided by the backend this will
+    /// simply be `nil`.
+    let distance: Double?
 }
 
 struct AddressDTO: Decodable {
@@ -85,6 +90,8 @@ struct Business: Identifiable {
     let description: String
     let priceRange: String
     let rating: Double
+    /// Distance in meters from the user's location if available.
+    let distance: Double?
     let address: Address?
     let tags: [Tag]
     let promotions: [Promotion]
@@ -130,6 +137,7 @@ enum BusinessMapper {
             description: dto.description ?? "",
             priceRange: dto.priceRange ?? "",
             rating: dto.avgRating,
+            distance: dto.distance,
             address: AddressMapper.map(dto.address),
             tags: dto.tags.map(TagMapper.map),
             promotions: dto.promotions.map(PromotionMapper.map)


### PR DESCRIPTION
## Summary
- add price range, promo and address filters in business view model
- add sort menu and filter menu to home view to control search results
- include distance field in business model for sorting

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689faf33aae08323854c80badc7c40c4