### PR TITLE
Add reset button and view model reset for business search

### DIFF
--- a/IOS/Features/BusinessViewModel.swift
+++ b/IOS/Features/BusinessViewModel.swift
@@ -178,6 +178,22 @@ final class BusinessViewModel: ObservableObject {
         addressFilter = AddressFilter()
         applyFiltersAndSort()
     }
+
+    /// Restore default state and fetch businesses again
+    func reset() async {
+        // Reset search and selection state
+        searchTerm = ""
+        selectedFilter = nil
+        sortOption = .rating
+
+        // Reset advanced filters
+        priceRangeFilter = nil
+        hasActivePromoFilter = nil
+        addressFilter = AddressFilter()
+
+        // Reload businesses with the cleared criteria
+        await search()
+    }
 }
 
 // MARK: - Supporting Types

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -53,6 +53,10 @@ struct HomeView: View {
                             Button("Ara") {
                                 Task { await viewModel.search() }
                             }
+
+                            Button("Temizle") {
+                                Task { await viewModel.reset() }
+                            }
                         }
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 16) {


### PR DESCRIPTION
## Summary
- Add `Temizle` button in HomeView to clear search term and filters
- Introduce `BusinessViewModel.reset()` to restore initial state and refetch results

## Testing
- `swift test` *(fails: unable to access https://github.com/supabase-community/supabase-swift.git/ : CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fb27376788323b2ba07f6235c9335