### PR TITLE
feat: configure API client

### DIFF
--- a/IOS/Core/APIClient.swift
+++ b/IOS/Core/APIClient.swift
@@ -20,9 +20,9 @@ final class APIClient: APIClientProtocol {
     private var authData: AuthData?
     private(set) var message: String?
 
-    init(baseURL: URL = AppConfiguration.apiBaseURL,
+    init(baseURL: URL? = nil,
          session: URLSession = .shared) {
-        self.baseURL = baseURL
+        self.baseURL = baseURL ?? AppConfiguration.apiBaseURL
         self.session = session
     }
 


### PR DESCRIPTION
## Summary
- allow APIClient to accept optional base URL during initialization
- prepare requests with authentication and JSON body handling

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fb93460c883239299ece4e337c760