### PR TITLE
Configure environment-based settings and restrict ATS

### DIFF
--- a/IOS/Core/AppConfiguration.swift
+++ b/IOS/Core/AppConfiguration.swift
@@ -2,21 +2,26 @@ import Foundation
 
 enum AppConfiguration {
     private static let info: [String: Any] = {
-        if let envBaseURL = ProcessInfo.processInfo.environment["API_BASE_URL"],
-           let envSupabaseURL = ProcessInfo.processInfo.environment["SUPABASE_URL"],
-           let envSupabaseKey = ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"] {
-            return [
-                "API_BASE_URL": envBaseURL,
-                "SUPABASE_URL": envSupabaseURL,
-                "SUPABASE_ANON_KEY": envSupabaseKey
-            ]
+        var config: [String: Any] = [:]
+
+        if let url = Bundle.module.url(forResource: "Configuration", withExtension: "plist"),
+           let data = try? Data(contentsOf: url),
+           let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] {
+            config = dict
         }
-        guard let url = Bundle.module.url(forResource: "Configuration", withExtension: "plist"),
-              let data = try? Data(contentsOf: url),
-              let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
-            return [:]
+
+        let env = ProcessInfo.processInfo.environment
+        if let envBaseURL = env["API_BASE_URL"] {
+            config["API_BASE_URL"] = envBaseURL
         }
-        return dict
+        if let envSupabaseURL = env["SUPABASE_URL"] {
+            config["SUPABASE_URL"] = envSupabaseURL
+        }
+        if let envSupabaseKey = env["SUPABASE_ANON_KEY"] {
+            config["SUPABASE_ANON_KEY"] = envSupabaseKey
+        }
+
+        return config
     }()
 
     static var apiBaseURL: URL {

--- a/IOS/Info.plist
+++ b/IOS/Info.plist
@@ -26,8 +26,11 @@
     <array>
         <string>UIInterfaceOrientationPortrait</string>
     </array>
-    <!-- No ATS exceptions defined; HTTP-based tests will not run on real devices -->
+    <!-- Only HTTPS connections are allowed; no ATS exceptions -->
     <key>NSAppTransportSecurity</key>
-    <dict/>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- load API and Supabase settings from Configuration.plist with environment variable overrides
- restrict App Transport Security to HTTPS only

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf6621d88323b58dc07b8caa4a23