### PR TITLE
Implement secure auth storage and login flow

### DIFF
--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -9,7 +9,6 @@ final class AuthViewModel: ObservableObject {
     @Published var isAuthenticated: Bool
 
     private let service = AuthService()
-    private let session = UserSession.shared
     private let userService = UserService()
     private let appViewModel: AppViewModel
 
@@ -17,8 +16,7 @@ final class AuthViewModel: ObservableObject {
         self.appViewModel = appViewModel
         self.isAuthenticated = appViewModel.isAuthenticated
 
-        if let auth = service.getAuthData() {
-            session.save(userId: auth.user?.id, token: auth.accessToken)
+        if service.getAuthData() != nil {
             appViewModel.isAuthenticated = true
             isAuthenticated = true
         }
@@ -28,8 +26,6 @@ final class AuthViewModel: ObservableObject {
     func login() async {
         do {
             let data = try await service.login(email: email, password: password, role: role)
-            session.save(userId: data.user?.id, token: data.accessToken)
-            service.saveAuthData(data)
             if let id = data.user?.id {
                 try await userService.fetchUserData(userId: id, role: role)
             }

--- a/IOS/Services/AuthService.swift
+++ b/IOS/Services/AuthService.swift
@@ -3,22 +3,34 @@ import Foundation
 /// Handles authentication related network operations.
 final class AuthService {
     private let api: APIClientProtocol
-    private let authStorageKey = "authData"
+    private let storage: SecureStorage
+    private let userIdKey = "userId"
+    private let accessTokenKey = "access_token"
+    private let refreshTokenKey = "refresh_token"
 
-    init(api: APIClientProtocol = APIClient.shared) {
+    init(api: APIClientProtocol = APIClient.shared, storage: SecureStorage = .shared) {
         self.api = api
+        self.storage = storage
     }
 
     // MARK: - Networking
     func sendVerificationCode(email: String) async throws -> EmptyResponse {
         let body = try JSONEncoder().encode(["email": email])
-        let response: EmptyResponse = try await api.request("api/auth/send-verification-code", method: "POST", body: body)
+        let response: EmptyResponse = try await api.request(
+            "api/auth/send-verification-code",
+            method: "POST",
+            body: body
+        )
         return response
     }
 
     func verifyCode(email: String, token: String) async throws -> VerificationResponse {
         let body = try JSONEncoder().encode(["email": email, "token": token])
-        let response: VerificationResponse = try await api.request("api/auth/verify-verification-code", method: "POST", body: body)
+        let response: VerificationResponse = try await api.request(
+            "api/auth/verify-verification-code",
+            method: "POST",
+            body: body
+        )
         return response
     }
 
@@ -29,29 +41,63 @@ final class AuthService {
     }
 
     func login(email: String, password: String, role: String) async throws -> AuthData {
-        let body = try JSONEncoder().encode(["email": email, "password": password, "role": role])
-        let auth: AuthData = try await api.request("api/auth/login", method: "POST", body: body)
-        api.setAuthData(auth)
+        let body = try JSONEncoder().encode([
+            "email": email,
+            "password": password,
+            "role": role
+        ])
+        let auth: AuthData = try await api.request(
+            "api/auth/login",
+            method: "POST",
+            body: body
+        )
+        saveAuthData(auth)
+        return auth
+    }
+
+    func checkPassword(email: String, password: String) async throws -> AuthData {
+        let body = try JSONEncoder().encode([
+            "email": email,
+            "password": password,
+            "role": "user"
+        ])
+        let auth: AuthData = try await api.request(
+            "api/auth/login",
+            method: "POST",
+            body: body
+        )
         return auth
     }
 
     // MARK: - Auth Storage
     func saveAuthData(_ data: AuthData) {
-        if let encoded = try? JSONEncoder().encode(data) {
-            UserDefaults.standard.set(encoded, forKey: authStorageKey)
+        if let id = data.user?.id {
+            storage.save(id, for: userIdKey)
         }
+        storage.save(data.accessToken, for: accessTokenKey)
+        storage.save(data.refreshToken, for: refreshTokenKey)
         api.setAuthData(data)
     }
 
     func getAuthData() -> AuthData? {
-        guard let data = UserDefaults.standard.data(forKey: authStorageKey) else { return nil }
-        let auth = try? JSONDecoder().decode(AuthData.self, from: data)
-        if let auth { api.setAuthData(auth) }
+        guard
+            let access = storage.read(for: accessTokenKey),
+            let refresh = storage.read(for: refreshTokenKey)
+        else { return nil }
+        let userId = storage.read(for: userIdKey)
+        let user: User? = {
+            if let id = userId { return User(id: id, email: nil, emailConfirmedAt: nil, appMetadata: nil) }
+            return nil
+        }()
+        let auth = AuthData(accessToken: access, refreshToken: refresh, user: user)
+        api.setAuthData(auth)
         return auth
     }
 
     func logout() {
-        UserDefaults.standard.removeObject(forKey: authStorageKey)
+        storage.delete(key: userIdKey)
+        storage.delete(key: accessTokenKey)
+        storage.delete(key: refreshTokenKey)
         api.setAuthData(nil)
     }
 }


### PR DESCRIPTION
## Summary
- Hook authentication calls to `/api/auth/*` endpoints with a new `checkPassword` helper
- Persist `userId`, `access_token`, and `refresh_token` in `SecureStorage` and clear them on logout
- Update `AuthViewModel` to use `AuthService` and set `AppViewModel.isAuthenticated` on successful login

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fc08e639c832387aa76c8f6f0d17d