### PR TITLE
Split business logic into dedicated view models

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct RestaurantRow: View {
     let restaurant: Restaurant
-    @EnvironmentObject var listViewModel: BusinessViewModel
+    @EnvironmentObject var listViewModel: HomeViewModel
 
     var body: some View {
         HStack(alignment: .top) {
@@ -57,5 +57,5 @@ struct RestaurantRow: View {
             promotions: []
         )
     )
-    .environmentObject(BusinessViewModel())
+    .environmentObject(HomeViewModel())
 }

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -4,7 +4,7 @@ import CoreLocation
 struct HomeView: View {
     @EnvironmentObject var appViewModel: AppViewModel
     @EnvironmentObject var authViewModel: AuthViewModel
-    @StateObject private var viewModel = BusinessViewModel()
+    @StateObject private var viewModel = HomeViewModel()
     @StateObject private var locationManager = LocationManager()
     @State private var showLogin = false
     @State private var showProfile = false

--- a/IOS/Features/Home/HomeViewModel.swift
+++ b/IOS/Features/Home/HomeViewModel.swift
@@ -2,13 +2,10 @@ import Foundation
 import CoreLocation
 
 @MainActor
-final class BusinessViewModel: ObservableObject {
+final class HomeViewModel: ObservableObject {
     @Published var topRated: [Restaurant] = []
     /// Results after applying filters and sorting
     @Published var searchResults: [Restaurant] = []
-    @Published var selectedBusiness: Restaurant?
-    @Published var promotions: [Promotion] = []
-    @Published var reviews: [Review] = []
     @Published var errorMessage: String?
     @Published var searchTerm: String = ""
     @Published var selectedFilter: FilterType?
@@ -68,30 +65,6 @@ final class BusinessViewModel: ObservableObject {
                 allResults = try await service.getByTag(tag)
                 applyFiltersAndSort()
             }
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    func fetchBusiness(id: String) async {
-        do {
-            selectedBusiness = try await service.getBusinessById(id)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    func fetchPromotions(businessId: String) async {
-        do {
-            promotions = try await service.getBusinessPromotions(businessId)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    func fetchReviews(businessId: String) async {
-        do {
-            reviews = try await service.getBusinessReviews(businessId)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -251,3 +224,4 @@ enum FilterType: String, CaseIterable {
         }
     }
 }
+

--- a/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct RestaurantDetailView: View {
     let businessId: String
-    @StateObject private var viewModel = BusinessViewModel()
+    @StateObject private var viewModel = RestaurantDetailViewModel()
 
     var body: some View {
         List {

--- a/IOS/Features/RestaurantDetail/RestaurantDetailViewModel.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@MainActor
+final class RestaurantDetailViewModel: ObservableObject {
+    @Published var selectedBusiness: Restaurant?
+    @Published var promotions: [Promotion] = []
+    @Published var reviews: [Review] = []
+    @Published var errorMessage: String?
+
+    private let service = BusinessService()
+
+    func fetchBusiness(id: String) async {
+        do {
+            selectedBusiness = try await service.getBusinessById(id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fetchPromotions(businessId: String) async {
+        do {
+            promotions = try await service.getBusinessPromotions(businessId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fetchReviews(businessId: String) async {
+        do {
+            reviews = try await service.getBusinessReviews(businessId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func markReviewViewed(_ reviewId: String) async {
+        do {
+            _ = try await service.setViewed(reviewId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -36,8 +36,9 @@ struct PromotionDTO: Decodable {
     let description: String?
     let startDate: String?
     let endDate: String?
-    /// Backend now returns promotion amounts as integers. Support decoding either
-    /// an integer or a double value to maintain backwards compatibility.
+    /// Promotion discount amount represented as an optional integer to avoid
+    /// floating point precision issues. Old backend versions might return a
+    /// double which is coerced to `Int` during decoding.
     let amount: Int?
     let active: Bool
     let createdAt: String?
@@ -135,6 +136,7 @@ struct Tag: Identifiable {
 
 // MARK: - Mappers
 enum BusinessMapper {
+    /// Converts a backend `BusinessDTO` into the app's `Business` model.
     static func map(_ dto: BusinessDTO) -> Business {
         Business(
             id: dto.id,

--- a/IOS/Services/BusinessService.swift
+++ b/IOS/Services/BusinessService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Service responsible for fetching business related data from backend.
+/// Service responsible for fetching business related data from backend via `APIClient`.
 final class BusinessService {
     private let api: APIClientProtocol
     private let base = "api/business"


### PR DESCRIPTION
## Summary
- Use APIClient throughout BusinessService
- Map business and promotion DTOs with optional Int amounts
- Introduce HomeViewModel and RestaurantDetailViewModel for search, filters, top-rated, reviews, and promotions

## Testing
- `swift test` *(failed: unable to clone supabase-swift due to 403)*
- `npm test` *(failed: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fc361389883239ad2c2a5bfa900c2