### PR TITLE
Add business mapper and review DTO

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -52,6 +52,7 @@ struct RestaurantRow: View {
             priceRange: "$$",
             rating: 4.5,
             distance: 1500,
+            imageURL: "",
             address: Address(id: "a1", street: "Main St", city: "City", district: "District", neighborhood: "Neighborhood"),
             tags: [Tag(id: "t1", name: "Fast Food")],
             promotions: []

--- a/IOS/IOSTests/BusinessServiceTests.swift
+++ b/IOS/IOSTests/BusinessServiceTests.swift
@@ -3,7 +3,18 @@ import XCTest
 
 final class BusinessServiceTests: XCTestCase {
     func testGetAllBusinessesSuccess() async throws {
-        let dto = BusinessDTO(id: "1", name: "T", description: nil, priceRange: nil, avgRating: 4.0, address: nil, tags: [], promotions: [])
+        let dto = BusinessDTO(
+            id: "1",
+            name: "T",
+            description: nil,
+            priceRange: nil,
+            avgRating: 4.0,
+            address: nil,
+            tags: [],
+            promotions: [],
+            photos: nil,
+            distance: nil
+        )
         let mock = MockAPIClient()
         mock.result = [dto]
         let service = BusinessService(api: mock)

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -1,89 +1,5 @@
 import Foundation
 
-// MARK: - DTOs from backend
-struct BusinessDTO: Decodable, Identifiable {
-    let id: String
-    let name: String
-    let description: String?
-    let priceRange: String?
-    let avgRating: Double
-    let address: AddressDTO?
-    let tags: [TagDTO]
-    let promotions: [PromotionDTO]
-    /// Optional distance in meters from the user's location. Some endpoints
-    /// such as `/nearby` include this value which can then be used for sorting
-    /// purposes on the client side. When not provided by the backend this will
-    /// simply be `nil`.
-    let distance: Double?
-}
-
-struct AddressDTO: Decodable {
-    let id: String?
-    let street: String?
-    let city: String?
-    let district: String?
-    let neighborhood: String?
-}
-
-struct TagDTO: Decodable {
-    let id: String
-    let name: String
-}
-
-struct PromotionDTO: Decodable {
-    let id: String
-    let title: String
-    let description: String?
-    let startDate: String?
-    let endDate: String?
-    /// Promotion discount amount represented as an optional integer to avoid
-    /// floating point precision issues. Old backend versions might return a
-    /// double which is coerced to `Int` during decoding.
-    let amount: Int?
-    let active: Bool
-    let createdAt: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case id, title, description, startDate, endDate, amount, active, createdAt
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(String.self, forKey: .id)
-        title = try container.decode(String.self, forKey: .title)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
-        startDate = try container.decodeIfPresent(String.self, forKey: .startDate)
-        endDate = try container.decodeIfPresent(String.self, forKey: .endDate)
-        if let intAmount = try container.decodeIfPresent(Int.self, forKey: .amount) {
-            amount = intAmount
-        } else if let doubleAmount = try container.decodeIfPresent(Double.self, forKey: .amount) {
-            amount = Int(doubleAmount)
-        } else {
-            amount = nil
-        }
-        active = try container.decode(Bool.self, forKey: .active)
-        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
-    }
-}
-
-struct ReviewDTO: Decodable {
-    let id: String
-    let reviewerName: String?
-    let rating: Double
-    let comment: String?
-}
-
-struct ReviewInfoForBusinessDTO: Decodable {
-    let review: InnerReview
-    let reviewerName: String?
-
-    struct InnerReview: Decodable {
-        let id: String
-        let comment: String?
-        let rating: Double
-    }
-}
-
 // MARK: - Domain models
 struct Business: Identifiable {
     let id: String
@@ -93,6 +9,8 @@ struct Business: Identifiable {
     let rating: Double
     /// Distance in meters from the user's location if available.
     let distance: Double?
+    /// URL of the cover image associated with the business.
+    let imageURL: String
     let address: Address?
     let tags: [Tag]
     let promotions: [Promotion]
@@ -132,78 +50,4 @@ struct Address: Identifiable {
 struct Tag: Identifiable {
     let id: String
     let name: String
-}
-
-// MARK: - Mappers
-enum BusinessMapper {
-    /// Converts a backend `BusinessDTO` into the app's `Business` model.
-    static func map(_ dto: BusinessDTO) -> Business {
-        Business(
-            id: dto.id,
-            name: dto.name,
-            description: dto.description ?? "",
-            priceRange: dto.priceRange ?? "",
-            rating: dto.avgRating,
-            distance: dto.distance,
-            address: AddressMapper.map(dto.address),
-            tags: dto.tags.map(TagMapper.map),
-            promotions: dto.promotions.map(PromotionMapper.map)
-        )
-    }
-}
-
-enum PromotionMapper {
-    static func map(_ dto: PromotionDTO) -> Promotion {
-        Promotion(
-            id: dto.id,
-            title: dto.title,
-            description: dto.description ?? "",
-            startDate: dto.startDate,
-            endDate: dto.endDate,
-            amount: dto.amount,
-            isActive: dto.active,
-            createdAt: dto.createdAt
-        )
-    }
-}
-
-enum ReviewMapper {
-    static func map(_ dto: ReviewDTO) -> Review {
-        Review(
-            id: dto.id,
-            reviewerName: dto.reviewerName ?? "",
-            rating: dto.rating,
-            comment: dto.comment ?? ""
-        )
-    }
-}
-
-enum ReviewInfoMapper {
-    static func map(_ dto: ReviewInfoForBusinessDTO) -> Review {
-        Review(
-            id: dto.review.id,
-            reviewerName: dto.reviewerName ?? "",
-            rating: dto.review.rating,
-            comment: dto.review.comment ?? ""
-        )
-    }
-}
-
-enum AddressMapper {
-    static func map(_ dto: AddressDTO?) -> Address? {
-        guard let dto = dto else { return nil }
-        return Address(
-            id: dto.id ?? "",
-            street: dto.street ?? "",
-            city: dto.city ?? "",
-            district: dto.district ?? "",
-            neighborhood: dto.neighborhood ?? ""
-        )
-    }
-}
-
-enum TagMapper {
-    static func map(_ dto: TagDTO) -> Tag {
-        Tag(id: dto.id, name: dto.name)
-    }
 }

--- a/IOS/Models/BusinessMapper.swift
+++ b/IOS/Models/BusinessMapper.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+// MARK: - DTOs from backend
+struct BusinessDTO: Decodable, Identifiable {
+    let id: String
+    let name: String
+    let description: String?
+    let priceRange: String?
+    let avgRating: Double
+    let address: AddressDTO?
+    let tags: [TagDTO]
+    let promotions: [PromotionDTO]
+    let photos: [PhotoDTO]?
+    /// Optional distance in meters from the user's location. Some endpoints
+    /// such as `/nearby` include this value which can then be used for sorting
+    /// purposes on the client side. When not provided by the backend this will
+    /// simply be `nil`.
+    let distance: Double?
+}
+
+struct AddressDTO: Decodable {
+    let id: String?
+    let street: String?
+    let city: String?
+    let district: String?
+    let neighborhood: String?
+}
+
+struct TagDTO: Decodable {
+    let id: String
+    let name: String
+}
+
+struct PromotionDTO: Decodable {
+    let id: String
+    let title: String
+    let description: String?
+    let startDate: String?
+    let endDate: String?
+    /// Promotion discount amount represented as an optional integer to avoid
+    /// floating point precision issues. Old backend versions might return a
+    /// double which is coerced to `Int` during decoding.
+    let amount: Int?
+    let active: Bool
+    let createdAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, description, startDate, endDate, amount, active, createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        startDate = try container.decodeIfPresent(String.self, forKey: .startDate)
+        endDate = try container.decodeIfPresent(String.self, forKey: .endDate)
+        if let intAmount = try container.decodeIfPresent(Int.self, forKey: .amount) {
+            amount = intAmount
+        } else if let doubleAmount = try container.decodeIfPresent(Double.self, forKey: .amount) {
+            amount = Int(doubleAmount)
+        } else {
+            amount = nil
+        }
+        active = try container.decode(Bool.self, forKey: .active)
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
+    }
+}
+
+struct PhotoDTO: Decodable {
+    let id: String
+    let url: String
+    let caption: String?
+    let cover: Bool
+}
+
+struct ReviewDTO: Decodable {
+    let id: String
+    let reviewerName: String?
+    let rating: Double
+    let comment: String?
+}
+
+struct ReviewInfoForBusinessDTO: Decodable {
+    let review: InnerReview
+    let reviewerName: String?
+
+    struct InnerReview: Decodable {
+        let id: String
+        let comment: String?
+        let rating: Double
+    }
+}
+
+// MARK: - Mappers
+enum BusinessMapper {
+    /// Converts a backend `BusinessDTO` into the app's `Business` model.
+    static func map(_ dto: BusinessDTO) -> Business {
+        let coverPhoto = dto.photos?.first(where: { $0.cover }) ?? dto.photos?.first
+        return Business(
+            id: dto.id,
+            name: dto.name,
+            description: dto.description ?? "",
+            priceRange: dto.priceRange ?? "",
+            rating: dto.avgRating,
+            distance: dto.distance,
+            imageURL: coverPhoto?.url ?? "",
+            address: AddressMapper.map(dto.address),
+            tags: dto.tags.map(TagMapper.map),
+            promotions: dto.promotions.map(PromotionMapper.map)
+        )
+    }
+}
+
+enum PromotionMapper {
+    static func map(_ dto: PromotionDTO) -> Promotion {
+        Promotion(
+            id: dto.id,
+            title: dto.title,
+            description: dto.description ?? "",
+            startDate: dto.startDate,
+            endDate: dto.endDate,
+            amount: dto.amount,
+            isActive: dto.active,
+            createdAt: dto.createdAt
+        )
+    }
+}
+
+enum ReviewMapper {
+    static func map(_ dto: ReviewDTO) -> Review {
+        Review(
+            id: dto.id,
+            reviewerName: dto.reviewerName ?? "",
+            rating: dto.rating,
+            comment: dto.comment ?? ""
+        )
+    }
+}
+
+enum ReviewInfoMapper {
+    static func map(_ dto: ReviewInfoForBusinessDTO) -> Review {
+        Review(
+            id: dto.review.id,
+            reviewerName: dto.reviewerName ?? "",
+            rating: dto.review.rating,
+            comment: dto.review.comment ?? ""
+        )
+    }
+}
+
+enum AddressMapper {
+    static func map(_ dto: AddressDTO?) -> Address? {
+        guard let dto = dto else { return nil }
+        return Address(
+            id: dto.id ?? "",
+            street: dto.street ?? "",
+            city: dto.city ?? "",
+            district: dto.district ?? "",
+            neighborhood: dto.neighborhood ?? ""
+        )
+    }
+}
+
+enum TagMapper {
+    static func map(_ dto: TagDTO) -> Tag {
+        Tag(id: dto.id, name: dto.name)
+    }
+}


### PR DESCRIPTION
## Summary
- add BusinessMapper to convert BusinessDTO into Business with promotions, cover image and tags
- extend Business model with more details and imageURL field
- map /reviews/{businessId} responses to Review via ReviewInfoForBusinessDTO and ReviewInfoMapper

## Testing
- `swift test` *(fails: unable to access supabase-swift dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689fcae4a00483238ef031bb6e6084ba