### PR TITLE
Refactor iOS features with navigation stack and shared UI components

### DIFF
--- a/IOS/Components/ErrorAlert.swift
+++ b/IOS/Components/ErrorAlert.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ErrorAlert: ViewModifier {
+    @Binding var message: String?
+
+    func body(content: Content) -> some View {
+        content.alert("Error", isPresented: Binding(
+            get: { message != nil },
+            set: { _ in message = nil }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(message ?? "")
+        }
+    }
+}
+
+extension View {
+    func errorAlert(_ message: Binding<String?>) -> some View {
+        modifier(ErrorAlert(message: message))
+    }
+}
+
+#Preview {
+    Text("Preview").modifier(ErrorAlert(message: .constant("Sample error")))
+}

--- a/IOS/Components/LoadingView.swift
+++ b/IOS/Components/LoadingView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.3).ignoresSafeArea()
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .padding()
+                .background(Color(.systemBackground))
+                .cornerRadius(8)
+        }
+    }
+}
+
+#Preview {
+    LoadingView()
+}

--- a/IOS/FeastFineiOSApp.swift
+++ b/IOS/FeastFineiOSApp.swift
@@ -13,7 +13,7 @@ struct FeastFineiOSApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Group {
+            NavigationStack {
                 if appViewModel.isAuthenticated {
                     HomeView()
                 } else {

--- a/IOS/Features/Auth/LoginView.swift
+++ b/IOS/Features/Auth/LoginView.swift
@@ -4,27 +4,25 @@ struct LoginView: View {
     @EnvironmentObject private var viewModel: AuthViewModel
     
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                TextField("Email", text: $viewModel.email)
-                    .textFieldStyle(.roundedBorder)
-                SecureField("Password", text: $viewModel.password)
-                    .textFieldStyle(.roundedBorder)
-                if let message = viewModel.errorMessage {
-                    Text(message).foregroundColor(.red)
-                }
-                Button("Login") {
-                    Task {
-                        await viewModel.login()
-                    }
-                }
-                NavigationLink("Register") {
-                    RegisterEmailView()
+        VStack(spacing: 16) {
+            TextField("Email", text: $viewModel.email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $viewModel.password)
+                .textFieldStyle(.roundedBorder)
+            if let message = viewModel.errorMessage {
+                Text(message).foregroundColor(.red)
+            }
+            Button("Login") {
+                Task {
+                    await viewModel.login()
                 }
             }
-            .padding()
-            .navigationTitle("Login")
+            NavigationLink("Register") {
+                RegisterEmailView()
+            }
         }
+        .padding()
+        .navigationTitle("Login")
     }
 }
 

--- a/IOS/Features/Favorites/FavoritesView.swift
+++ b/IOS/Features/Favorites/FavoritesView.swift
@@ -21,15 +21,14 @@ struct FavoritesView: View {
             await viewModel.loadFavorites()
         }
         .overlay {
-            VStack {
-                if let status = viewModel.statusMessage {
-                    Text(status).foregroundColor(.green)
-                }
-                if let error = viewModel.errorMessage {
-                    Text(error).foregroundColor(.red)
-                }
+            if viewModel.isLoading { LoadingView() }
+        }
+        .overlay(alignment: .bottom) {
+            if let status = viewModel.statusMessage {
+                Text(status).foregroundColor(.green)
             }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/Favorites/FavoritesViewModel.swift
+++ b/IOS/Features/Favorites/FavoritesViewModel.swift
@@ -5,14 +5,25 @@ final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [Restaurant] = []
     @Published var errorMessage: String?
     @Published var statusMessage: String?
+    @Published var isLoading = false
 
-    private let service = ListService()
-    private let userService = UserService()
-    private let session = UserSession.shared
+    private let service: ListService
+    private let userService: UserService
+    private let session: UserSession
+
+    init(service: ListService = ListService(),
+         userService: UserService = UserService(),
+         session: UserSession = .shared) {
+        self.service = service
+        self.userService = userService
+        self.session = session
+    }
 
     func loadFavorites() async {
         guard let userId = session.getUserId(),
               let favoritesId = userService.getUserFavoritesIdFromStorage() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             favorites = try await service.getUserListItems(userId: userId, listId: favoritesId)
             errorMessage = nil
@@ -25,6 +36,8 @@ final class FavoritesViewModel: ObservableObject {
 
     func removeFavorite(_ id: String) async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             favorites = try await service.toggleFavorite(userId: userId, itemId: id)
             statusMessage = "Removed from favorites"

--- a/IOS/Features/Home/HomeView.swift
+++ b/IOS/Features/Home/HomeView.swift
@@ -11,8 +11,7 @@ struct HomeView: View {
     @State private var showAddressSheet = false
 
     var body: some View {
-        NavigationView {
-            List {
+        List {
                 Section {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
@@ -129,7 +128,7 @@ struct HomeView: View {
                 ProfileView()
             }
             .sheet(isPresented: $showAddressSheet) {
-                NavigationView {
+                NavigationStack {
                     Form {
                         Section("Adres") {
                             TextField("City", text: $viewModel.addressFilter.city)
@@ -157,18 +156,14 @@ struct HomeView: View {
                 await viewModel.search()
                 await viewModel.refreshFavorites()
             }
+            .overlay {
+                if viewModel.isLoading { LoadingView() }
+            }
             .onReceive(locationManager.$userLocation.compactMap { $0 }) { location in
                 viewModel.userLocation = location
                 Task { await viewModel.fetchNearby() }
             }
-            .alert("Error", isPresented: Binding(
-                get: { viewModel.errorMessage != nil },
-                set: { _ in viewModel.errorMessage = nil }
-            )) {
-                Button("OK", role: .cancel) { }
-            } message: {
-                Text(viewModel.errorMessage ?? "")
-            }
+            .errorAlert($viewModel.errorMessage)
             .alert("Location Error", isPresented: Binding(
                 get: { locationManager.locationStatus != nil },
                 set: { _ in locationManager.locationStatus = nil }
@@ -180,7 +175,6 @@ struct HomeView: View {
             .onChange(of: authViewModel.isAuthenticated) { isAuth in
                 if isAuth { showLogin = false }
             }
-        }
     }
 }
 

--- a/IOS/Features/InsideDiscover/InsideDiscoverView.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverView.swift
@@ -12,10 +12,9 @@ struct InsideDiscoverView: View {
             await viewModel.loadTopRated()
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
-            }
+            if viewModel.isLoading { LoadingView() }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
@@ -4,10 +4,17 @@ import Foundation
 final class InsideDiscoverViewModel: ObservableObject {
     @Published var businesses: [Restaurant] = []
     @Published var errorMessage: String?
+    @Published var isLoading = false
+    
+    private let service: BusinessService
 
-    private let service = BusinessService()
+    init(service: BusinessService = BusinessService()) {
+        self.service = service
+    }
 
     func loadTopRated() async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             businesses = try await service.getTopRated()
             errorMessage = nil

--- a/IOS/Features/InsideList/InsideListView.swift
+++ b/IOS/Features/InsideList/InsideListView.swift
@@ -22,15 +22,14 @@ struct InsideListView: View {
             await viewModel.loadItems(listId: list.id)
         }
         .overlay {
-            VStack {
-                if let status = viewModel.statusMessage {
-                    Text(status).foregroundColor(.green)
-                }
-                if let error = viewModel.errorMessage {
-                    Text(error).foregroundColor(.red)
-                }
+            if viewModel.isLoading { LoadingView() }
+        }
+        .overlay(alignment: .bottom) {
+            if let status = viewModel.statusMessage {
+                Text(status).foregroundColor(.green)
             }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/InsideList/InsideListViewModel.swift
+++ b/IOS/Features/InsideList/InsideListViewModel.swift
@@ -5,12 +5,20 @@ final class InsideListViewModel: ObservableObject {
     @Published var items: [Restaurant] = []
     @Published var errorMessage: String?
     @Published var statusMessage: String?
+    @Published var isLoading = false
 
-    private let service = ListService()
-    private let session = UserSession.shared
+    private let service: ListService
+    private let session: UserSession
+
+    init(service: ListService = ListService(), session: UserSession = .shared) {
+        self.service = service
+        self.session = session
+    }
 
     func loadItems(listId: String) async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             items = try await service.getUserListItems(userId: userId, listId: listId)
             errorMessage = nil
@@ -23,6 +31,8 @@ final class InsideListViewModel: ObservableObject {
 
     func removeItem(listId: String, itemId: String) async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             _ = try await service.removeFromList(userId: userId, listId: listId, itemId: itemId)
             await loadItems(listId: listId)

--- a/IOS/Features/MyReviews/MyReviewsView.swift
+++ b/IOS/Features/MyReviews/MyReviewsView.swift
@@ -24,10 +24,9 @@ struct MyReviewsView: View {
             await viewModel.loadReviews()
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
-            }
+            if viewModel.isLoading { LoadingView() }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/MyReviews/MyReviewsViewModel.swift
+++ b/IOS/Features/MyReviews/MyReviewsViewModel.swift
@@ -4,12 +4,20 @@ import Foundation
 final class MyReviewsViewModel: ObservableObject {
     @Published var reviews: [UserReview] = []
     @Published var errorMessage: String?
+    @Published var isLoading = false
 
-    private let service = UserService()
-    private let session = UserSession.shared
+    private let service: UserService
+    private let session: UserSession
+
+    init(service: UserService = UserService(), session: UserSession = .shared) {
+        self.service = service
+        self.session = session
+    }
 
     func loadReviews() async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             reviews = try await service.getUserReviews(userId: userId)
             errorMessage = nil

--- a/IOS/Features/Profile/ProfileView.swift
+++ b/IOS/Features/Profile/ProfileView.swift
@@ -21,11 +21,6 @@ struct ProfileView: View {
                 Button("Save") {
                     Task { await viewModel.updateProfile(name: name, surname: surname, phoneNumber: phoneNumber, email: email) }
                 }
-            } else if let error = viewModel.errorMessage {
-                Text(error)
-                    .foregroundColor(.red)
-            } else {
-                ProgressView()
             }
         }
         .padding()
@@ -38,6 +33,10 @@ struct ProfileView: View {
                 email = profile.email ?? ""
             }
         }
+        .overlay {
+            if viewModel.isLoading { LoadingView() }
+        }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/Profile/ProfileViewModel.swift
+++ b/IOS/Features/Profile/ProfileViewModel.swift
@@ -4,12 +4,20 @@ import Foundation
 final class ProfileViewModel: ObservableObject {
     @Published var profile: UserProfile?
     @Published var errorMessage: String?
+    @Published var isLoading = false
 
-    private let service = UserService()
-    private let session = UserSession.shared
+    private let service: UserService
+    private let session: UserSession
+
+    init(service: UserService = UserService(), session: UserSession = .shared) {
+        self.service = service
+        self.session = session
+    }
 
     func loadProfile() async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             profile = try await service.getUserData(userId: userId)
             errorMessage = nil
@@ -21,6 +29,8 @@ final class ProfileViewModel: ObservableObject {
     func updateProfile(name: String, surname: String?, phoneNumber: String?, email: String?) async {
         guard let userId = session.getUserId() else { return }
         let updated = UserProfile(id: userId, name: name, email: email, surname: surname, phoneNumber: phoneNumber)
+        isLoading = true
+        defer { isLoading = false }
         do {
             profile = try await service.updateUserData(userId: userId, profile: updated)
             errorMessage = nil

--- a/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
@@ -61,6 +61,10 @@ struct RestaurantDetailView: View {
                 await viewModel.fetchReviews(businessId: businessId)
             }
         }
+        .overlay {
+            if viewModel.isLoading { LoadingView() }
+        }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/RestaurantDetail/RestaurantDetailViewModel.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailViewModel.swift
@@ -6,10 +6,17 @@ final class RestaurantDetailViewModel: ObservableObject {
     @Published var promotions: [Promotion] = []
     @Published var reviews: [Review] = []
     @Published var errorMessage: String?
+    @Published var isLoading = false
+    
+    private let service: BusinessService
 
-    private let service = BusinessService()
+    init(service: BusinessService = BusinessService()) {
+        self.service = service
+    }
 
     func fetchBusiness(id: String) async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             selectedBusiness = try await service.getBusinessById(id)
         } catch {
@@ -18,6 +25,8 @@ final class RestaurantDetailViewModel: ObservableObject {
     }
 
     func fetchPromotions(businessId: String) async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             promotions = try await service.getBusinessPromotions(businessId)
         } catch {
@@ -26,6 +35,8 @@ final class RestaurantDetailViewModel: ObservableObject {
     }
 
     func fetchReviews(businessId: String) async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             reviews = try await service.getBusinessReviews(businessId)
         } catch {
@@ -34,6 +45,8 @@ final class RestaurantDetailViewModel: ObservableObject {
     }
 
     func markReviewViewed(_ reviewId: String) async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             _ = try await service.setViewed(reviewId)
         } catch {

--- a/IOS/Features/RestaurantRegistration/RestaurantRegistrationView.swift
+++ b/IOS/Features/RestaurantRegistration/RestaurantRegistrationView.swift
@@ -12,10 +12,9 @@ struct RestaurantRegistrationView: View {
             await viewModel.loadOwnedBusinesses()
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
-            }
+            if viewModel.isLoading { LoadingView() }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/RestaurantRegistration/RestaurantRegistrationViewModel.swift
+++ b/IOS/Features/RestaurantRegistration/RestaurantRegistrationViewModel.swift
@@ -4,12 +4,20 @@ import Foundation
 final class RestaurantRegistrationViewModel: ObservableObject {
     @Published var restaurants: [Restaurant] = []
     @Published var errorMessage: String?
+    @Published var isLoading = false
 
-    private let service = BusinessService()
-    private let session = UserSession.shared
+    private let service: BusinessService
+    private let session: UserSession
+
+    init(service: BusinessService = BusinessService(), session: UserSession = .shared) {
+        self.service = service
+        self.session = session
+    }
 
     func loadOwnedBusinesses() async {
         guard let ownerId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             restaurants = try await service.getBusinessesByOwner(ownerId)
             errorMessage = nil

--- a/IOS/Features/UserLists/UserListsView.swift
+++ b/IOS/Features/UserLists/UserListsView.swift
@@ -12,10 +12,9 @@ struct UserListsView: View {
             await viewModel.loadLikes()
         }
         .overlay {
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
-            }
+            if viewModel.isLoading { LoadingView() }
         }
+        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/UserLists/UserListsViewModel.swift
+++ b/IOS/Features/UserLists/UserListsViewModel.swift
@@ -4,12 +4,20 @@ import Foundation
 final class UserListsViewModel: ObservableObject {
     @Published var likedLists: [UserLike] = []
     @Published var errorMessage: String?
+    @Published var isLoading = false
 
-    private let service = UserService()
-    private let session = UserSession.shared
+    private let service: UserService
+    private let session: UserSession
+
+    init(service: UserService = UserService(), session: UserSession = .shared) {
+        self.service = service
+        self.session = session
+    }
 
     func loadLikes() async {
         guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             likedLists = try await service.getUserLikes(userId: userId)
             errorMessage = nil


### PR DESCRIPTION
## Summary
- Introduce reusable `LoadingView` and `ErrorAlert` components
- Move Favorites and Inside List features into dedicated folders and inject services into view models
- Replace root navigation with `NavigationStack` so Home appears after login

## Testing
- `swift test` *(fails: unable to clone dependency `supabase-swift` due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fcc801db883239109b80dac68e7b7