### PR TITLE
Handle app auth state and auto login

### DIFF
--- a/IOS/AppViewModel.swift
+++ b/IOS/AppViewModel.swift
@@ -3,4 +3,12 @@ import Foundation
 @MainActor
 final class AppViewModel: ObservableObject {
     @Published var isAuthenticated: Bool = false
+
+    private let authService = AuthService()
+
+    init() {
+        if authService.getAuthData() != nil {
+            isAuthenticated = true
+        }
+    }
 }

--- a/IOS/Features/Auth/AuthViewModel.swift
+++ b/IOS/Features/Auth/AuthViewModel.swift
@@ -15,11 +15,6 @@ final class AuthViewModel: ObservableObject {
     init(appViewModel: AppViewModel) {
         self.appViewModel = appViewModel
         self.isAuthenticated = appViewModel.isAuthenticated
-
-        if service.getAuthData() != nil {
-            appViewModel.isAuthenticated = true
-            isAuthenticated = true
-        }
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- manage auth state centrally with `AppViewModel`
- sync `AuthViewModel` changes with `AppViewModel`
- automatically log in if stored token exists

## Testing
- `swift test` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fce59f69083238e96cdd3447abe87