### PR TITLE
Add UIKit import to SaveToListsSheet

### DIFF
--- a/IOS/Components/SaveToListsSheet.swift
+++ b/IOS/Components/SaveToListsSheet.swift
@@ -1,3 +1,4 @@
+import UIKit
 import SwiftUI
 
 struct SaveToListsSheet: View {


### PR DESCRIPTION
## Summary
- Import UIKit in `SaveToListsSheet` so haptic feedback generators compile.

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*
- `swiftc IOS/Components/SaveToListsSheet.swift -typecheck` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_689ff4b3a57883239fa5360e941db537