### PR TITLE
Enable list-based discovery view

### DIFF
--- a/IOS/Features/InsideDiscover/InsideDiscoverView.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverView.swift
@@ -1,15 +1,18 @@
 import SwiftUI
 
 struct InsideDiscoverView: View {
+    let listId: String
     @StateObject private var viewModel = InsideDiscoverViewModel()
+    @StateObject private var homeViewModel = HomeViewModel()
 
     var body: some View {
         List(viewModel.businesses) { business in
-            Text(business.name)
+            RestaurantRow(restaurant: business)
+                .environmentObject(homeViewModel)
         }
         .navigationTitle("Discover")
         .task {
-            await viewModel.loadTopRated()
+            await viewModel.loadListItems(listId: listId)
         }
         .overlay {
             if viewModel.isLoading { LoadingView() }
@@ -19,5 +22,5 @@ struct InsideDiscoverView: View {
 }
 
 #Preview {
-    InsideDiscoverView()
+    InsideDiscoverView(listId: "1")
 }

--- a/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
+++ b/IOS/Features/InsideDiscover/InsideDiscoverViewModel.swift
@@ -5,11 +5,17 @@ final class InsideDiscoverViewModel: ObservableObject {
     @Published var businesses: [Restaurant] = []
     @Published var errorMessage: String?
     @Published var isLoading = false
-    
-    private let service: BusinessService
 
-    init(service: BusinessService = BusinessService()) {
+    private let service: BusinessService
+    private let listService: ListService
+    private let session: UserSession
+
+    init(service: BusinessService = BusinessService(),
+         listService: ListService = ListService(),
+         session: UserSession = .shared) {
         self.service = service
+        self.listService = listService
+        self.session = session
     }
 
     func loadTopRated() async {
@@ -22,6 +28,18 @@ final class InsideDiscoverViewModel: ObservableObject {
             // Temporarily disable error popup for top rated
             print("⚠️ Top rated fetch failed: \(error.localizedDescription)")
             // errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadListItems(listId: String) async {
+        guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            businesses = try await listService.getUserListItems(userId: userId, listId: listId)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary
- load user list items in `InsideDiscoverViewModel` via `ListService.getUserListItems`
- accept `listId` in `InsideDiscoverView` and render restaurants with `RestaurantRow`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0deaa5b388323b05fa377512a6c96