### PR TITLE
feat: add segmented user list view with like support

### DIFF
--- a/IOS/Features/UserLists/UserListsView.swift
+++ b/IOS/Features/UserLists/UserListsView.swift
@@ -4,12 +4,32 @@ struct UserListsView: View {
     @StateObject private var viewModel = UserListsViewModel()
 
     var body: some View {
-        List(viewModel.likedLists) { like in
-            Text(like.name ?? "Unnamed")
+        VStack {
+            Picker("Mode", selection: $viewModel.mode) {
+                Text("Listelerim").tag(UserListsViewModel.Mode.myLists)
+                Text("Keşfet").tag(UserListsViewModel.Mode.explore)
+            }
+            .pickerStyle(.segmented)
+
+            List(viewModel.lists) { list in
+                HStack {
+                    Text(list.name)
+                    Spacer()
+                    Button {
+                        Task { await viewModel.toggleLike(list) }
+                    } label: {
+                        Image(systemName: viewModel.likedListIds.contains(list.id) ? "heart.fill" : "heart")
+                            .foregroundColor(.red)
+                    }
+                }
+            }
         }
-        .navigationTitle("User Lists")
+        .navigationTitle("Listeler")
         .task {
-            await viewModel.loadLikes()
+            await viewModel.load()
+        }
+        .onChange(of: viewModel.mode) { _ in
+            Task { await viewModel.loadLists() }
         }
         .overlay {
             if viewModel.isLoading { LoadingView() }

--- a/IOS/Features/UserLists/UserListsViewModel.swift
+++ b/IOS/Features/UserLists/UserListsViewModel.swift
@@ -2,24 +2,71 @@ import Foundation
 
 @MainActor
 final class UserListsViewModel: ObservableObject {
-    @Published var likedLists: [UserLike] = []
+    enum Mode { case myLists, explore }
+
+    @Published var mode: Mode = .myLists
+    @Published var lists: [UserList] = []
+    @Published var likedListIds: Set<String> = []
     @Published var errorMessage: String?
     @Published var isLoading = false
 
-    private let service: UserService
+    private let listService: ListService
+    private let userService: UserService
     private let session: UserSession
 
-    init(service: UserService = UserService(), session: UserSession = .shared) {
-        self.service = service
+    init(listService: ListService = ListService(),
+         userService: UserService = UserService(),
+         session: UserSession = .shared) {
+        self.listService = listService
+        self.userService = userService
         self.session = session
+    }
+
+    func load() async {
+        await loadLists()
+        await loadLikes()
+    }
+
+    func loadLists() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            switch mode {
+            case .myLists:
+                guard let userId = session.getUserId() else { return }
+                lists = try await listService.getUserLists(userId: userId)
+            case .explore:
+                lists = try await listService.getPublicLists()
+            }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     func loadLikes() async {
         guard let userId = session.getUserId() else { return }
+        do {
+            let likes = try await userService.getUserLikes(userId: userId)
+            likedListIds = Set(likes.map { $0.listId })
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleLike(_ list: UserList) async {
+        guard let userId = session.getUserId() else { return }
         isLoading = true
         defer { isLoading = false }
         do {
-            likedLists = try await service.getUserLikes(userId: userId)
+            if likedListIds.contains(list.id) {
+                _ = try await userService.removeLike(userId: userId, listId: list.id)
+                likedListIds.remove(list.id)
+            } else {
+                _ = try await userService.addLike(userId: userId, listId: list.id)
+                likedListIds.insert(list.id)
+            }
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- add segmented control to switch between user and public lists
- fetch lists from ListService and manage likes via UserService
- enable liking and unliking lists

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0e0c0f54883239aaddfa0546a9f0c