### PR TITLE
Add password change and logout to profile

### DIFF
--- a/IOS/Features/Profile/ProfileView.swift
+++ b/IOS/Features/Profile/ProfileView.swift
@@ -2,10 +2,14 @@ import SwiftUI
 
 struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    @EnvironmentObject private var appViewModel: AppViewModel
     @State private var name: String = ""
     @State private var surname: String = ""
     @State private var phoneNumber: String = ""
     @State private var email: String = ""
+    @State private var newPassword: String = ""
+    @State private var confirmPassword: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -20,6 +24,25 @@ struct ProfileView: View {
                     .textFieldStyle(.roundedBorder)
                 Button("Save") {
                     Task { await viewModel.updateProfile(name: name, surname: surname, phoneNumber: phoneNumber, email: email) }
+                }
+                SecureField("New Password", text: $newPassword)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("Confirm Password", text: $confirmPassword)
+                    .textFieldStyle(.roundedBorder)
+                Button("Change Password") {
+                    guard newPassword == confirmPassword else {
+                        viewModel.errorMessage = "Passwords do not match"
+                        return
+                    }
+                    Task {
+                        await viewModel.changePassword(newPassword: newPassword)
+                        newPassword = ""
+                        confirmPassword = ""
+                    }
+                }
+                Button("Logout") {
+                    authViewModel.logout()
+                    appViewModel.isAuthenticated = false
                 }
             }
         }

--- a/IOS/Features/Profile/ProfileViewModel.swift
+++ b/IOS/Features/Profile/ProfileViewModel.swift
@@ -38,4 +38,16 @@ final class ProfileViewModel: ObservableObject {
             errorMessage = error.localizedDescription
         }
     }
+
+    func changePassword(newPassword: String) async {
+        guard let userId = session.getUserId() else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            _ = try await service.changePassword(userId: userId, newPassword: newPassword)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add new password fields and buttons for changing password and logging out in `ProfileView`
- Implement `changePassword` in `ProfileViewModel` using `UserService`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e241a3bc8323af88bd9362c26bb1