### PR TITLE
Sort public lists by likes and show like counts

### DIFF
--- a/IOS/Features/UserLists/UserListsView.swift
+++ b/IOS/Features/UserLists/UserListsView.swift
@@ -15,6 +15,8 @@ struct UserListsView: View {
                 HStack {
                     Text(list.name)
                     Spacer()
+                    Text("\(list.likeCount)")
+                        .foregroundColor(.secondary)
                     Button {
                         Task { await viewModel.toggleLike(list) }
                     } label: {

--- a/IOS/Features/UserLists/UserListsViewModel.swift
+++ b/IOS/Features/UserLists/UserListsViewModel.swift
@@ -36,12 +36,17 @@ final class UserListsViewModel: ObservableObject {
                 guard let userId = session.getUserId() else { return }
                 lists = try await listService.getUserLists(userId: userId)
             case .explore:
-                lists = try await listService.getPublicLists()
+                lists = try await fetchPublicLists()
             }
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    func fetchPublicLists() async throws -> [UserList] {
+        let publicLists = try await listService.getPublicLists()
+        return publicLists.sorted { $0.likeCount > $1.likeCount }
     }
 
     func loadLikes() async {


### PR DESCRIPTION
## Summary
- Sort public lists by like count in `UserListsViewModel`
- Display like counts in `UserListsView`

## Testing
- `swift test` *(fails: unable to clone dependencies, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e484cfb8832397186355558adb64