### PR TITLE
Add service test scenarios and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: apple/swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.1'
+      - name: Run tests
+        run: swift test --xunit-output TestResults.xml
+      - name: Upload test results
+        uses: actions/upload-test-results@v2
+        with:
+          files: TestResults.xml

--- a/IOS/IOSTests/AuthServiceTests.swift
+++ b/IOS/IOSTests/AuthServiceTests.swift
@@ -36,7 +36,7 @@ final class AuthServiceTests: XCTestCase {
         XCTAssertEqual(saved?.user?.id, "u1")
     }
 
-    func testLoginFailure() async {
+    func testLoginFailureDoesNotStoreAuthData() async {
         let json = """
         {"message":"not found"}
         """
@@ -44,5 +44,16 @@ final class AuthServiceTests: XCTestCase {
         await XCTAssertThrowsError(try await service.login(email: "e", password: "p", role: "user")) { error in
             XCTAssertEqual(error as? APIError, .notFound)
         }
+        XCTAssertNil(service.getAuthData())
+    }
+
+    func testSaveAuthDataStoresTokens() {
+        let service = AuthService(api: makeClient(body: "{}"), storage: storage)
+        let auth = AuthData(accessToken: "a", refreshToken: "r", user: User(id: "u1", email: nil, emailConfirmedAt: nil, appMetadata: nil))
+        service.saveAuthData(auth)
+        let saved = service.getAuthData()
+        XCTAssertEqual(saved?.accessToken, "a")
+        XCTAssertEqual(saved?.refreshToken, "r")
+        XCTAssertEqual(saved?.user?.id, "u1")
     }
 }

--- a/IOS/IOSTests/BusinessServiceTests.swift
+++ b/IOS/IOSTests/BusinessServiceTests.swift
@@ -32,4 +32,24 @@ final class BusinessServiceTests: XCTestCase {
             XCTAssertEqual(error as? APIError, .serverError)
         }
     }
+
+    func testGetBusinessByIdSuccess() async throws {
+        let json = """
+        {"id":"1","name":"Cafe","description":null,"priceRange":null,"avgRating":4.0,"address":null,"tags":[],"promotions":[],"photos":null,"distance":null}
+        """
+        let service = BusinessService(api: makeClient(body: json))
+        let business = try await service.getBusinessById("1")
+        XCTAssertEqual(business.id, "1")
+        XCTAssertEqual(business.name, "Cafe")
+    }
+
+    func testGetBusinessByIdFailure() async {
+        let json = """
+        {"message":"not found"}
+        """
+        let service = BusinessService(api: makeClient(statusCode: 404, body: json))
+        await XCTAssertThrowsError(try await service.getBusinessById("1")) { error in
+            XCTAssertEqual(error as? APIError, .notFound)
+        }
+    }
 }

--- a/IOS/IOSTests/ListServiceTests.swift
+++ b/IOS/IOSTests/ListServiceTests.swift
@@ -32,4 +32,24 @@ final class ListServiceTests: XCTestCase {
             XCTAssertEqual(error as? APIError, .forbidden)
         }
     }
+
+    func testCreateListSuccess() async throws {
+        let json = """
+        {"id":"1","name":"Favorites","is_favorite":false,"is_public":true,"like_counter":0}
+        """
+        let service = ListService(api: makeClient(body: json))
+        let list = try await service.createList(userId: "u1", name: "Favorites", isPublic: true)
+        XCTAssertEqual(list.id, "1")
+        XCTAssertEqual(list.name, "Favorites")
+    }
+
+    func testCreateListFailure() async {
+        let json = """
+        {"message":"bad"}
+        """
+        let service = ListService(api: makeClient(statusCode: 400, body: json))
+        await XCTAssertThrowsError(try await service.createList(userId: "u1", name: "Favorites", isPublic: true)) { error in
+            XCTAssertEqual(error as? APIError, .badRequest("bad"))
+        }
+    }
 }

--- a/IOS/IOSTests/UserServiceTests.swift
+++ b/IOS/IOSTests/UserServiceTests.swift
@@ -48,4 +48,24 @@ final class UserServiceTests: XCTestCase {
         XCTAssertEqual(fetched?.userId, "u1")
         XCTAssertEqual(fetched?.token, "tok")
     }
+
+    func testGetUserLikesSuccess() async throws {
+        let json = """
+        [{"id":"like1","listId":"l1","name":"Favorites"}]
+        """
+        let service = UserService(api: makeClient(body: json), storage: storage)
+        let likes = try await service.getUserLikes(userId: "u1")
+        XCTAssertEqual(likes.count, 1)
+        XCTAssertEqual(likes.first?.listId, "l1")
+    }
+
+    func testGetUserLikesFailure() async {
+        let json = """
+        {"message":"server"}
+        """
+        let service = UserService(api: makeClient(statusCode: 500, body: json), storage: storage)
+        await XCTAssertThrowsError(try await service.getUserLikes(userId: "u1")) { error in
+            XCTAssertEqual(error as? APIError, .serverError)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand ListService, UserService, BusinessService tests to cover success and failure cases using MockURLProtocol
- add AuthService tests for login failure and token storage
- configure CI workflow to run tests and publish results

## Testing
- `swift test` *(fails: unable to clone supabase-swift repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a1031c92708323b049ee792a54aa97