### PR TITLE
feat: add gallery and review tabs

### DIFF
--- a/IOS/Components/RestaurantRow.swift
+++ b/IOS/Components/RestaurantRow.swift
@@ -53,6 +53,7 @@ struct RestaurantRow: View {
             rating: 4.5,
             distance: 1500,
             imageURL: "",
+            photos: [],
             address: Address(id: "a1", street: "Main St", city: "City", district: "District", neighborhood: "Neighborhood"),
             tags: [Tag(id: "t1", name: "Fast Food")],
             promotions: []

--- a/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantDetailView.swift
@@ -4,8 +4,78 @@ struct RestaurantDetailView: View {
     let businessId: String
     @StateObject private var viewModel = RestaurantDetailViewModel()
     @State private var showSaveToListsSheet = false
+    @State private var isFavorite = false
+    @State private var selectedTab: DetailTab = .overview
+
+    enum DetailTab: String, CaseIterable, Identifiable {
+        case overview, reviews, photos
+        var id: Self { self }
+        var title: String {
+            switch self {
+            case .overview: return "Overview"
+            case .reviews: return "Reviews"
+            case .photos: return "Photos"
+            }
+        }
+    }
 
     var body: some View {
+        VStack {
+            Picker("Tab", selection: $selectedTab) {
+                ForEach(DetailTab.allCases) { tab in
+                    Text(tab.title).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding([.horizontal, .top])
+
+            content
+        }
+        .navigationTitle(viewModel.selectedBusiness?.name ?? "")
+        .toolbar {
+            Button(action: {
+                isFavorite.toggle()
+                if isFavorite {
+                    showSaveToListsSheet = true
+                }
+            }) {
+                Image(systemName: isFavorite ? "heart.fill" : "heart")
+                    .foregroundColor(.red)
+            }
+        }
+        .task {
+            // Paralel API çağrıları - tüm veriler aynı anda yüklenir
+            async let business = viewModel.fetchBusiness(id: businessId)
+            async let promotions = viewModel.fetchPromotions(businessId: businessId)
+            async let reviews = viewModel.fetchReviews(businessId: businessId)
+
+            // Hepsinin tamamlanmasını bekle
+            await business
+            await promotions
+            await reviews
+        }
+        .overlay {
+            if viewModel.isLoading { LoadingView() }
+        }
+        .sheet(isPresented: $showSaveToListsSheet) {
+            SaveToListsSheet(businessId: businessId)
+        }
+        .errorAlert($viewModel.errorMessage)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch selectedTab {
+        case .overview:
+            overview
+        case .reviews:
+            RestaurantReviewView(reviews: viewModel.reviews)
+        case .photos:
+            PhotoGalleryView(imageURLs: viewModel.selectedBusiness?.photos ?? [])
+        }
+    }
+
+    private var overview: some View {
         List {
             if let business = viewModel.selectedBusiness {
                 VStack(alignment: .leading, spacing: 8) {
@@ -13,7 +83,7 @@ struct RestaurantDetailView: View {
                         .font(.title)
                     Text(business.description)
                     HStack {
-                        Text("⭐️ \(String(format: "%.1f", business.rating))")
+                        Text("⭐️ \\(String(format: "%.1f", business.rating))")
                         Text(business.priceRange)
                     }
                     .font(.subheadline)
@@ -41,53 +111,56 @@ struct RestaurantDetailView: View {
                     }
                 }
             }
+        }
+    }
+}
 
-            if !viewModel.reviews.isEmpty {
-                Section("Reviews") {
-                    ForEach(viewModel.reviews) { review in
-                        VStack(alignment: .leading) {
-                            Text(review.reviewerName).bold()
-                            Text(review.comment)
-                        }
+struct PhotoGalleryView: View {
+    let imageURLs: [String]
+
+    var body: some View {
+        TabView {
+            ForEach(imageURLs, id: \.self) { url in
+                ZoomableAsyncImage(urlString: url)
+            }
+        }
+        .tabViewStyle(.page)
+        .frame(height: 250)
+    }
+}
+
+private struct ZoomableAsyncImage: View {
+    let urlString: String
+    @State private var scale: CGFloat = 1.0
+
+    var body: some View {
+        GeometryReader { _ in
+            ScrollView([.horizontal, .vertical], showsIndicators: false) {
+                AsyncImage(url: URL(string: urlString)) { phase in
+                    if let image = phase.image {
+                        image
+                            .resizable()
+                            .scaledToFit()
+                            .scaleEffect(scale)
+                            .gesture(
+                                MagnificationGesture()
+                                    .onChanged { value in
+                                        scale = value
+                                    }
+                                    .onEnded { value in
+                                        withAnimation {
+                                            scale = max(1.0, value)
+                                        }
+                                    }
+                            )
+                    } else if phase.error != nil {
+                        Color.red
+                    } else {
+                        ProgressView()
                     }
                 }
             }
-            
-            // Save to Lists Section
-            Section {
-                Button(action: {
-                    showSaveToListsSheet = true
-                }) {
-                    HStack {
-                        Image(systemName: "heart.fill")
-                            .foregroundColor(.red)
-                        Text("Listelerime Ekle")
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .foregroundColor(.primary)
-            }
         }
-        .task {
-            // Paralel API çağrıları - tüm veriler aynı anda yüklenir
-            async let business = viewModel.fetchBusiness(id: businessId)
-            async let promotions = viewModel.fetchPromotions(businessId: businessId)
-            async let reviews = viewModel.fetchReviews(businessId: businessId)
-            
-            // Hepsinin tamamlanmasını bekle
-            await business
-            await promotions
-            await reviews
-        }
-        .overlay {
-            if viewModel.isLoading { LoadingView() }
-        }
-        .sheet(isPresented: $showSaveToListsSheet) {
-            SaveToListsSheet(businessId: businessId)
-        }
-        .errorAlert($viewModel.errorMessage)
     }
 }
 

--- a/IOS/Features/RestaurantDetail/RestaurantReviewView.swift
+++ b/IOS/Features/RestaurantDetail/RestaurantReviewView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct RestaurantReviewView: View {
+    let reviews: [Review]
+    @State private var selectedRating: Int?
+
+    private var filteredReviews: [Review] {
+        if let rating = selectedRating {
+            return reviews.filter { Int($0.rating.rounded()) == rating }
+        } else {
+            return reviews
+        }
+    }
+
+    var body: some View {
+        VStack {
+            Picker("Rating", selection: $selectedRating) {
+                Text("All").tag(Int?.none)
+                ForEach((1...5).reversed(), id: \.self) { value in
+                    Text("\(value)★").tag(Optional(value))
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            List(filteredReviews) { review in
+                VStack(alignment: .leading) {
+                    HStack(spacing: 2) {
+                        ForEach(1...5, id: \.self) { star in
+                            Image(systemName: star <= Int(review.rating.rounded()) ? "star.fill" : "star")
+                                .foregroundColor(.yellow)
+                        }
+                        Text(review.reviewerName)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    if !review.comment.isEmpty {
+                        Text(review.comment)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+#Preview {
+    RestaurantReviewView(reviews: [Review(id: "1", reviewerName: "A", rating: 4, comment: "Good")])
+}

--- a/IOS/Models/Business.swift
+++ b/IOS/Models/Business.swift
@@ -11,6 +11,8 @@ struct Business: Identifiable {
     let distance: Double?
     /// URL of the cover image associated with the business.
     let imageURL: String
+    /// URLs of all photos associated with the business.
+    let photos: [String]
     let address: Address?
     let tags: [Tag]
     let promotions: [Promotion]

--- a/IOS/Models/BusinessMapper.swift
+++ b/IOS/Models/BusinessMapper.swift
@@ -265,6 +265,7 @@ enum BusinessMapper {
             rating: dto.avgRating,
             distance: dto.distance,
             imageURL: coverPhoto?.url ?? "",
+            photos: dto.photos?.map { $0.url } ?? [],
             address: AddressMapper.map(dto.address),
             tags: dto.tags?.map(TagMapper.map) ?? [],
             promotions: dto.promotions?.map(PromotionMapper.map) ?? []


### PR DESCRIPTION
## Summary
- add segmented tabs for overview, reviews and photos
- show zoomable photo gallery in restaurant detail
- introduce review view with star icons and rating filters
- support multiple photo URLs in business model

## Testing
- `swift test` *(fails: unable to access github.com for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a10a12fe388323a1a6313cd713037b